### PR TITLE
merge 2 nulog images into 1

### DIFF
--- a/src/dashboard/Kibana/README.md
+++ b/src/dashboard/Kibana/README.md
@@ -1,4 +1,4 @@
-## deploy opendistro-es with kibana
+## deploy opendistro-es with Kibana
 
 ```
 1. git clone https://github.com/opendistro-for-elasticsearch/opendistro-build
@@ -7,7 +7,7 @@
 4. helm install opendistro-es opendistro-es-1.13.1.tgz
 ```
 
-## setup Kibana dashboard
+## setup Opni dashboard
 
 port forward kibana to localhost:
 ```
@@ -15,7 +15,12 @@ kubectl port-forward svc/opendistro-es-kibana-svc 5601:443
 ```
 then pls visit -> `localhost:5601`  with username: `admin`  and pwd: `admin`
 
-Import the example dashboard by click `Stack Management -> Saved Objects -> Import` and select `kibana-dashboard.ndjson` from this folder. Click Done and Check out the example Dashboard!
+---
+Import the Opni dashboard by following steps:
+1. click `Stack Management -> Saved Objects -> Import`
+2. hit `Import` under `Select a file to import`, select `opni-dashboard.ndjson` from this directory.
+3. Click the blue button `Import` at the bottom, and then click `Done`.
+Now you can navigate to `Kibana -> Dashboard` to try out the Opni Logs Dashboard.
 
 ## setup Kibana alert and Slack notification
 

--- a/src/k8s/services/nulog-inference-service-control-plane.yaml
+++ b/src/k8s/services/nulog-inference-service-control-plane.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nulog-inference-service-control-plane
-        image: tybalex/nulog-inference-service-control-plane:v0.1
+        image: tybalex/nulog-inference-service:v0.1
         imagePullPolicy: Always
         env:
         - name: NATS_SERVER_URL

--- a/src/models/nulog/NuLogParser.py
+++ b/src/models/nulog/NuLogParser.py
@@ -28,12 +28,13 @@ class LogParser:
         k=50,
         log_format="<Content>",
         model_name="nulog_model_latest.pt",
+        save_path="output/",
     ):
-        self.savePath = "output/"
+        self.savePath = save_path
         self.k = k
         self.df_log = None
         self.log_format = log_format
-        self.tokenizer = LogTokenizer()
+        self.tokenizer = LogTokenizer(self.savePath)
 
         if not os.path.exists(self.savePath):
             os.makedirs(self.savePath)

--- a/src/models/nulog/NuLogTokenizer.py
+++ b/src/models/nulog/NuLogTokenizer.py
@@ -6,7 +6,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(messa
 
 
 class LogTokenizer:
-    def __init__(self):
+    def __init__(self, filepath="output/"):
+        self.filepath = filepath
         self.word2index = {
             "<PAD>": 0,
             "<CLS>": 1,
@@ -36,10 +37,10 @@ class LogTokenizer:
             self.index2word[self.valid_words] = word
             self.valid_words += 1
 
-    def load_vocab(self, filepath="output/"):
+    def load_vocab(self):
         self.word2index = {}
         self.index2word = {}
-        with open(os.path.join(filepath, "vocab.txt"), "r") as fin:
+        with open(os.path.join(self.filepath, "vocab.txt"), "r") as fin:
             self.n_words = int(fin.readline().rstrip())
             self.valid_words = int(fin.readline().rstrip())
             logging.info("n_words : " + str(self.n_words))
@@ -49,8 +50,8 @@ class LogTokenizer:
                 self.index2word[idx] = word_i
                 self.word2index[word_i] = idx
 
-    def save_vocab(self, filepath="output/"):
-        with open(os.path.join(filepath, "vocab.txt"), "w") as fout:
+    def save_vocab(self):
+        with open(os.path.join(self.filepath, "vocab.txt"), "w") as fout:
             logging.info("n_words : " + str(self.n_words))
             logging.info("valid_words : " + str(self.valid_words))
             fout.write(str(self.n_words))

--- a/src/models/nulog/inference.py
+++ b/src/models/nulog/inference.py
@@ -5,12 +5,12 @@ import logging
 from NuLogParser import LogParser
 
 
-def init_model():
+def init_model(save_path="output/"):
     logging.info("initializing...")
     nr_epochs = 1
     num_samples = 0
 
-    parser = LogParser()
+    parser = LogParser(save_path=save_path)
     parser.tokenizer.load_vocab()
     parser.init_inference(nr_epochs=nr_epochs, num_samples=num_samples)
 

--- a/src/nulog-inference-service/Dockerfile
+++ b/src/nulog-inference-service/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.7-slim
+
+RUN apt-get update && apt-get install -y wget zip
 COPY ./nulog-inference-service/ /app/
 COPY ./utils/nats_wrapper.py /app/nats_wrapper.py
 COPY ./models/nulog/ /app/
@@ -12,4 +14,6 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 RUN pip install --no-cache-dir -r requirements.txt
+RUN wget https://opni-public.s3.us-east-2.amazonaws.com/pretrain-models/control-plane-model.zip && unzip control-plane-model.zip
+
 CMD [ "python", "start-nulog-inference.py" ]

--- a/src/nulog-inference-service/NulogServer.py
+++ b/src/nulog-inference-service/NulogServer.py
@@ -57,13 +57,13 @@ class NulogServer:
                 )
                 return
 
-    def load(self):
+    def load(self, save_path="output/"):
         if using_GPU:
             logging.debug("inferencing with GPU.")
         else:
             logging.debug("inferencing without GPU.")
         try:
-            self.parser = nuloginf.init_model()
+            self.parser = nuloginf.init_model(save_path=save_path)
             self.is_ready = True
             logging.info("Nulog model gets loaded.")
         except Exception as e:

--- a/src/nulog-inference-service/start-nulog-inference.py
+++ b/src/nulog-inference-service/start-nulog-inference.py
@@ -52,9 +52,11 @@ async def infer_logs(logs_queue):
     )
 
     nulog_predictor = NulogServer()
-    if not IS_CONTROL_PLANE_SERVICE:  ## control plane model is built-in in the image.
+    if IS_CONTROL_PLANE_SERVICE:
+        nulog_predictor.load(save_path="control-plane-output/")
+    else:
         nulog_predictor.download_from_minio()
-    nulog_predictor.load()
+        nulog_predictor.load()
 
     async def doc_generator(df):
         for index, document in df.iterrows():


### PR DESCRIPTION
the nulog workload image and control-plane image now get merged to use the same image
This makes the maintenance easier.
the nulog-CP-service will read from `control-plane-output/` dir with the pre-trained model, while the regular nulog-service (for workload apps) will read from `output/` dir as usual.