### PR TITLE
Make kibana nodeport

### DIFF
--- a/pkg/opnictl/commands/create.go
+++ b/pkg/opnictl/commands/create.go
@@ -65,6 +65,9 @@ func BuildCreateDemoCmd() *cobra.Command {
 					},
 					Elastic: v1alpha1.ChartOptions{
 						Enabled: true,
+						Set: map[string]intstr.IntOrString{
+							"kibana.service.type": intstr.FromString("NodePort"),
+						},
 					},
 					RancherLogging: v1alpha1.ChartOptions{
 						Enabled: opniDemo.Spec.Quickstart,


### PR DESCRIPTION
It's easier for the quickstart to expose Kibana as a nodeport service.  Also in the quickstart script we should wait for the user to trigger the anomaly injection