### PR TITLE
Separate e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -208,7 +208,8 @@ steps:
       - until test -f ./kubeconfig.yaml; do sleep 1s; done
       - cat /etc/resolv.conf
       - export KUBECONFIG=$(realpath kubeconfig.yaml)
-      - go test -v --tags=e2e ./...
+      - export E2E_USE_EXISTING=1
+      - scripts/e2e
     when:
       event:
         - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -134,14 +134,9 @@ steps:
       - name: docker
         path: /var/run/docker.sock
   - name: test
-    image: golang:1.16
+    image: rancher/dapper:v0.5.5
     commands:
-      - until test -f ./kubeconfig.yaml; do sleep 1s; done
-      - cat /etc/resolv.conf
-      - export KUBECONFIG=$(realpath kubeconfig.yaml)
-      - export SHORT=0
-      - export E2E_USE_EXISTING=1
-      - scripts/test
+      - dapper test
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -195,6 +190,32 @@ steps:
       ref:
         - refs/head/main
         - refs/tags/*
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+---
+kind: pipeline
+type: docker
+name: e2e-test
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: e2e-test
+    image: golang:1.17
+    commands:
+      - until test -f ./kubeconfig.yaml; do sleep 1s; done
+      - cat /etc/resolv.conf
+      - export KUBECONFIG=$(realpath kubeconfig.yaml)
+      - go test -v --tags=e2e ./...
+    when:
+      event:
+        - pull_request
+      branch:
+        - main
+      instance:
+        - drone-pr.rancher.io
 services:
   - name: k3dsvc
     image: rancher/k3d:4.4.8dind
@@ -213,3 +234,5 @@ volumes:
   - name: docker
     host:
       path: /var/run/docker.sock
+depends_on:
+  - build-amd64

--- a/apis/v1beta1/webhook_suite_test.go
+++ b/apis/v1beta1/webhook_suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 /*
 Copyright 2021.
 

--- a/controllers/demo/opnidemo_controller_test.go
+++ b/controllers/demo/opnidemo_controller_test.go
@@ -1,3 +1,6 @@
+//go:build demo && !e2e
+// +build demo,!e2e
+
 package demo
 
 import (

--- a/controllers/demo/suite_test.go
+++ b/controllers/demo/suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e && demo
+// +build !e2e,demo
+
 /*
 Copyright 2021.
 

--- a/controllers/logadapter_controller_test.go
+++ b/controllers/logadapter_controller_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package controllers
 
 import (

--- a/controllers/opnicluster_controller_test.go
+++ b/controllers/opnicluster_controller_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package controllers
 
 import (

--- a/controllers/pretrainedmodel_controller_test.go
+++ b/controllers/pretrainedmodel_controller_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package controllers
 
 import (

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 /*
 Copyright 2021.
 

--- a/pkg/opnictl/opnictl_suite_test.go
+++ b/pkg/opnictl/opnictl_suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package opnictl_test
 
 import (

--- a/pkg/opnictl/opnictl_test.go
+++ b/pkg/opnictl/opnictl_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package opnictl_test
 
 import (

--- a/pkg/resources/labels_test.go
+++ b/pkg/resources/labels_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package resources_test
 
 import (

--- a/pkg/resources/opnicluster/elastic/indices/elasticsearch_reconciler_test.go
+++ b/pkg/resources/opnicluster/elastic/indices/elasticsearch_reconciler_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package indices
 
 import (

--- a/pkg/resources/opnicluster/elastic/indices/elasticsearch_suite_test.go
+++ b/pkg/resources/opnicluster/elastic/indices/elasticsearch_suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package indices
 
 import (

--- a/pkg/resources/opnicluster/opnicluster_suite_test.go
+++ b/pkg/resources/opnicluster/opnicluster_suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package opnicluster_test
 
 import (

--- a/pkg/resources/resources_suite_test.go
+++ b/pkg/resources/resources_suite_test.go
@@ -1,3 +1,6 @@
+//go:build !e2e
+// +build !e2e
+
 package resources_test
 
 import (

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)/..
+
+ENVTEST_ASSETS_DIR=$(pwd)/testbin
+
+source ./hack/setup-envtest.sh
+
+mkdir -p ${ENVTEST_ASSETS_DIR}
+fetch_envtest_tools ${ENVTEST_ASSETS_DIR}
+setup_envtest_env ${ENVTEST_ASSETS_DIR}
+echo "** STARTING TEST ** [KUBECONFIG=${KUBECONFIG}]"
+go test -v --tags=e2e,demo ./... 

--- a/test/e2e/demo_test.go
+++ b/test/e2e/demo_test.go
@@ -1,3 +1,6 @@
+//go:build e2e && demo
+// +build e2e,demo
+
 package e2e
 
 import (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package e2e
 
 import (


### PR DESCRIPTION
Have separated e2e tests out to a separate outline to help solve resourcing issues.  E2e tests will also only run on the drone-pr instance, and only when a pull-request is opened.

The e2e-test pipeline is dependent on the build pipeline so won't run if previous steps fail.