### PR TITLE
Update version of OpniCluster to be 1.1.0

### DIFF
--- a/deploy/patches/versions.yaml
+++ b/deploy/patches/versions.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   version: v0.2.0
   elastic:
-    version: 1.13.2
+    version: 1.1.0


### PR DESCRIPTION
Update the version in OpniCluster crd to be 1.1.0 to reflect Opensearch versioning. 