### PR TITLE
Add ignore option to webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -66,6 +66,10 @@ webhooks:
       path: /highlander-opni-io-v1beta1-opnicluster
   failurePolicy: Fail
   name: highlander.opni.io
+  objectSelector:
+    matchExpressions:
+    - key: "quickening.opni.io"
+      operator: DoesNotExist
   rules:
   - apiGroups:
     - opni.io

--- a/deploy/manifests/10_operator.yaml
+++ b/deploy/manifests/10_operator.yaml
@@ -224,6 +224,10 @@ webhooks:
       path: /highlander-opni-io-v1beta1-opnicluster
   failurePolicy: Fail
   name: highlander.opni.io
+  objectSelector:
+    matchExpressions:
+    - key: "quickening.opni.io"
+      operator: DoesNotExist
   rules:
   - apiGroups:
     - opni.io


### PR DESCRIPTION
For helm chart installs we need a way to ignore the highlander webhook.  This is because there's no way to install the operator and wait for it to be ready before we apply the CRDs.