### PR TITLE
Update 20_cluster.yaml

### DIFF
--- a/deploy/manifests/20_cluster.yaml
+++ b/deploy/manifests/20_cluster.yaml
@@ -36,7 +36,7 @@ spec:
       enabled: false # metrics anomaly detection is currently beta
       prometheus:
         name: prometheus-name #The name of the prometheus resource
-        namespace: promethues-namespace #The namespace the prometheus resource is in
+        namespace: prometheus-namespace #The namespace the prometheus resource is in
   elastic:
     version: 1.1.0
   s3:

--- a/deploy/manifests/20_cluster.yaml
+++ b/deploy/manifests/20_cluster.yaml
@@ -34,7 +34,7 @@ spec:
       - name: control-plane
     metrics:
       enabled: false # metrics anomaly detection is currently beta
-      prometheuus:
+      prometheus:
         name: prometheus-name #The name of the prometheus resource
         namespace: promethues-namespace #The namespace the prometheus resource is in
   elastic:


### PR DESCRIPTION
Fixed typo in manifest for opni cluster creation

I am spending some time looking into rancher opni. Running through the quickstart guide, I ran into this issue when installing the yamls. Just a small typo that caused a conflict between the CRD and the manifest.