### PR TITLE
Fix sloth 

### DIFF
--- a/plugins/slo/pkg/slo/doc.go
+++ b/plugins/slo/pkg/slo/doc.go
@@ -1,0 +1,16 @@
+/*
+   Copyright [2021] [Xabier Larrakoetxea]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package slo

--- a/plugins/slo/pkg/slo/doc.go
+++ b/plugins/slo/pkg/slo/doc.go
@@ -1,4 +1,6 @@
 /*
+This package contains code redistributed from Sloth (https://github.com/slok/sloth) under the following license:
+
    Copyright [2021] [Xabier Larrakoetxea]
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,6 @@
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-   limitations under the License.
+   limitations under the License.x
 */
 package slo

--- a/plugins/slo/pkg/slo/doc.go
+++ b/plugins/slo/pkg/slo/doc.go
@@ -13,6 +13,6 @@ This package contains code redistributed from Sloth (https://github.com/slok/slo
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-   limitations under the License.x
+   limitations under the License.
 */
 package slo

--- a/plugins/slo/pkg/slo/generate.go
+++ b/plugins/slo/pkg/slo/generate.go
@@ -35,7 +35,7 @@ const (
 	sloObjectiveLabelName = "sloth_objective"
 )
 
-type ruleFmtWrapper struct {
+type SLORuleFmtWrapper struct {
 	SLIrules   []rulefmt.Rule
 	MetaRules  []rulefmt.Rule
 	AlertRules []rulefmt.Rule
@@ -338,7 +338,7 @@ func defaultSLOAlertGenerator(slo prometheus.SLO, sloAlert prometheus.AlertMeta,
 	}, nil
 }
 
-func GenerateSLO(slo prometheus.SLO, ctx context.Context, info info.Info, lg hclog.Logger) (*ruleFmtWrapper, error) {
+func GenerateSLO(slo prometheus.SLO, ctx context.Context, info info.Info, lg hclog.Logger) (*SLORuleFmtWrapper, error) {
 
 	// Generate with the MWWB alerts
 
@@ -350,32 +350,35 @@ func GenerateSLO(slo prometheus.SLO, ctx context.Context, info info.Info, lg hcl
 	if err != nil {
 		return nil, fmt.Errorf("Could not generate SLO alerts: %w", err)
 	}
-	lg.Info("Multiwindow-multiburn alerts generated")
+	lg.Info("Multiwindow-multiburn alerts successfully generated")
 
 	sliRecordingRules, err := GenerateSLIRecordingRules(ctx, slo, *as)
 	if err != nil {
 		return nil, fmt.Errorf("Could not generate SLO recording rules: %w", err)
 	}
+	lg.Info("Raw SLI recording rules successfully generated")
 
 	metaRecordingRules, err := GenerateMetadataRecordingRules(ctx, slo, as)
 	if err != nil {
 		return nil, fmt.Errorf("Could not generate metadata recording rules %w", err)
 	}
+	lg.Info("Error budget recording rules successfully generated")
 
 	alertRules, err := GenerateSLOAlertRules(ctx, slo, *as)
 	if err != nil {
 		return nil, fmt.Errorf("Could not generate SLO alert rules: %w", err)
 	}
+	lg.Info("SLO alert rules successfully generated")
 
-	return &ruleFmtWrapper{
+	return &SLORuleFmtWrapper{
 		SLIrules:   sliRecordingRules,
 		MetaRules:  metaRecordingRules,
 		AlertRules: alertRules,
 	}, nil
 }
 
-func GenerateNoSloth(slos *prometheus.SLOGroup, ctx context.Context, lg hclog.Logger) ([][]byte, error) {
-	res := make([][]byte, 0)
+func GeneratePrometheusNoSlothGenerator(slos *prometheus.SLOGroup, ctx context.Context, lg hclog.Logger) ([]SLORuleFmtWrapper, error) {
+	res := make([]SLORuleFmtWrapper, 0)
 	err := Validate(slos)
 	if err != nil {
 		return nil, err
@@ -390,8 +393,7 @@ func GenerateNoSloth(slos *prometheus.SLOGroup, ctx context.Context, lg hclog.Lo
 		if err != nil {
 			return nil, err
 		}
-		lg.Info(fmt.Sprintf("SLO generated: %+v", result))
-		// res = append(res, result)
+		res = append(res, *result)
 	}
 	return res, nil
 }

--- a/plugins/slo/pkg/slo/generate.go
+++ b/plugins/slo/pkg/slo/generate.go
@@ -1,0 +1,110 @@
+package slo
+
+// This file is for generating SLOs without the builtin sloth OO generator
+// which crashes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alexandreLamarre/sloth/core/alert"
+	"github.com/alexandreLamarre/sloth/core/info"
+	"github.com/alexandreLamarre/sloth/core/prometheus"
+	"github.com/hashicorp/go-hclog"
+	"github.com/prometheus/prometheus/model/rulefmt"
+)
+
+type ruleFmtWrapper struct {
+	SLIrules   []rulefmt.Rule
+	MetaRules  []rulefmt.Rule
+	AlertRules []rulefmt.Rule
+}
+
+func Validate(slos *prometheus.SLOGroup) error {
+	// TODO implement
+	// use prometheus field validators
+	return nil
+}
+
+func MergeLabels(sloLabel map[string]string, extraLabels map[string]string) map[string]string {
+	// TODO implement
+	return sloLabel
+}
+
+func GenerateMWWBAlerts(ctx context.Context, alertSLO alert.SLO) (*alert.MWMBAlertGroup, error) {
+	// TODO implement
+	return nil, nil
+}
+
+func GenerateSLIRecordingRUles(ctx context.Context, slo prometheus.SLO, alerts *alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+	// TODO implement
+	return nil, nil
+}
+
+func GenerateMetadataRecordingRules(ctx context.Context, slo prometheus.SLO, alerts *alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+	// TODO implement
+	return nil, nil
+}
+
+func GenerateSLOAlertRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+	// TODO implement
+	return nil, nil
+}
+
+func GenerateSLO(slo prometheus.SLO, ctx context.Context, info info.Info, lg hclog.Logger) (*ruleFmtWrapper, error) {
+
+	// Generate with the MWWB alerts
+
+	alertSLO := alert.SLO{
+		ID:        slo.ID,
+		Objective: slo.Objective,
+	}
+	as, err := GenerateMWWBAlerts(ctx, alertSLO)
+	if err != nil {
+		return nil, fmt.Errorf("Could not generate SLO alerts: %w", err)
+	}
+	lg.Info("Multiwindow-multiburn alerts generated")
+
+	sliRecordingRules, err := GenerateSLIRecordingRUles(ctx, slo, as)
+	if err != nil {
+		return nil, fmt.Errorf("Could not generate SLO recording rules: %w", err)
+	}
+
+	metaRecordingRules, err := GenerateMetadataRecordingRules(ctx, slo, as)
+	if err != nil {
+		return nil, fmt.Errorf("Could not generate metadata recording rules %w", err)
+	}
+
+	alertRules, err := GenerateSLOAlertRules(ctx, slo, *as)
+	if err != nil {
+		return nil, fmt.Errorf("Could not generate SLO alert rules: %w", err)
+	}
+
+	return &ruleFmtWrapper{
+		SLIrules:   sliRecordingRules,
+		MetaRules:  metaRecordingRules,
+		AlertRules: alertRules,
+	}, nil
+}
+
+func GenerateNoSloth(slos *prometheus.SLOGroup, ctx context.Context, lg hclog.Logger) ([][]byte, error) {
+	res := make([][]byte, 0)
+	err := Validate(slos)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, slo := range slos.SLOs {
+		extraLabels := map[string]string{}
+		slo.Labels = MergeLabels(slo.Labels, extraLabels)
+		i := info.Info{}
+
+		result, err := GenerateSLO(slo, ctx, i, lg)
+		if err != nil {
+			return nil, err
+		}
+		lg.Info(fmt.Sprintf("SLO generated: %+v", result))
+		// res = append(res, result)
+	}
+	return res, nil
+}

--- a/plugins/slo/pkg/slo/generate.go
+++ b/plugins/slo/pkg/slo/generate.go
@@ -47,6 +47,7 @@ func Validate(slos *prometheus.SLOGroup) error {
 	return nil
 }
 
+/// Reference : https://github.com/slok/sloth/blob/481c16f6602731d628dcbf6051e74c80cdc1acb2/internal/alert/alert.go#L30
 func GenerateMWWBAlerts(ctx context.Context, alertSLO alert.SLO, timeWindow time.Duration) (*alert.MWMBAlertGroup, error) {
 	windows := WindowDefaults(timeWindow)
 	errorBudget := 100 - alertSLO.Objective
@@ -128,6 +129,7 @@ func getAlertGroupWindows(alerts alert.MWMBAlertGroup) []time.Duration {
 	return res
 }
 
+/// Reference : https://github.com/slok/sloth/blob/eddd8145a696c3dc6d423e9d50cdb906186a52a3/internal/prometheus/recording_rules.go#L78
 func rawSLIRecordGenerator(slo prometheus.SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
 	// Render with our templated data.
 	sliExprTpl := fmt.Sprintf(`(%s)`, slo.SLI.Raw.ErrorRatioQuery)
@@ -158,6 +160,7 @@ func rawSLIRecordGenerator(slo prometheus.SLO, window time.Duration, alerts aler
 	}, nil
 }
 
+/// Reference : https://github.com/slok/sloth/blob/eddd8145a696c3dc6d423e9d50cdb906186a52a3/internal/prometheus/recording_rules.go#L205
 func GenerateMetadataRecordingRules(ctx context.Context, slo prometheus.SLO, alerts *alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	labels := MergeLabels(slo.GetSLOIDPromLabels(), slo.Labels)
 
@@ -258,6 +261,7 @@ func GenerateMetadataRecordingRules(ctx context.Context, slo prometheus.SLO, ale
 	return rules, nil
 }
 
+/// Reference : https://github.com/slok/sloth/blob/2de193572284e36189fe78ab33beb7e2b339b0f8/internal/prometheus/alert_rules.go#L25
 func GenerateSLOAlertRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	alertPageMetadata := prometheus.AlertMeta{
 		Disable: false,
@@ -281,6 +285,7 @@ func GenerateSLOAlertRules(ctx context.Context, slo prometheus.SLO, alerts alert
 	return rules, nil
 }
 
+/// Reference : https://github.com/slok/sloth/blob/2de193572284e36189fe78ab33beb7e2b339b0f8/internal/prometheus/alert_rules.go#L51
 func defaultSLOAlertGenerator(slo prometheus.SLO, sloAlert prometheus.AlertMeta, quick, slow alert.MWMBAlert) (*rulefmt.Rule, error) {
 	// Generate the filter labels based on the SLO ids.
 	metricFilter := labelsToPromFilter(slo.GetSLOIDPromLabels())

--- a/plugins/slo/pkg/slo/slo_test.go
+++ b/plugins/slo/pkg/slo/slo_test.go
@@ -246,9 +246,27 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 				Objective: 99.99,
 			}
 			ctx := context.Background()
-			_, err = slo.GenerateMWWBAlerts(ctx, alertSLO, time.Hour*24)
-			Expect(err).To(HaveOccurred())
+			alertGroup, err := slo.GenerateMWWBAlerts(ctx, alertSLO, time.Hour*24)
+			Expect(err).To(Succeed())
+			Expect(alertGroup).To(Not(BeNil()))
 		})
+
+		It("Should be able the generate rulefmt.Rules based on alertGroups", func() {
+			sampleSLO := simplePrometheusIR[0].SLOs[0]
+			ctx := context.Background()
+			alertSLO := alert.SLO{
+				ID:        "foo",
+				Objective: 99.99,
+			}
+			alertGroup, err := slo.GenerateMWWBAlerts(ctx, alertSLO, time.Hour*24)
+			Expect(err).To(Succeed())
+			rules, err := slo.GenerateSLIRecordingRules(ctx, sampleSLO, *alertGroup)
+			Expect(err).To(Succeed())
+			// TODO : better testing for this
+			Expect(rules).To(HaveLen(6))
+
+		})
+
 		It("Should create valid prometheus rules", func() {
 			var err error
 			simplePrometheusResponse, err = slo.GeneratePrometheusRule(simplePrometheusIR, context.Background())

--- a/plugins/slo/pkg/slo/slo_test.go
+++ b/plugins/slo/pkg/slo/slo_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 			Expect(alertGroup).To(Not(BeNil()))
 		})
 
-		It("Should be able the generate rulefmt.Rules based on alertGroups", func() {
+		It("Should be able to generate SLI rulefmt.Rules based on alertGroups and SLO definition", func() {
 			sampleSLO := simplePrometheusIR[0].SLOs[0]
 			ctx := context.Background()
 			alertSLO := alert.SLO{
@@ -262,9 +262,24 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 			Expect(err).To(Succeed())
 			rules, err := slo.GenerateSLIRecordingRules(ctx, sampleSLO, *alertGroup)
 			Expect(err).To(Succeed())
-			// TODO : better testing for this
+			// TODO : better testing for this when the final format is more stable
 			Expect(rules).To(HaveLen(6))
 
+		})
+
+		It("Should be able to generate metadata rulefmt.Rules based on alertGroups and SLO defintion", func() {
+			sampleSLO := simplePrometheusIR[0].SLOs[0]
+			ctx := context.Background()
+			alertSLO := alert.SLO{
+				ID:        "foo",
+				Objective: 99.99,
+			}
+			alertGroup, err := slo.GenerateMWWBAlerts(ctx, alertSLO, time.Hour*24)
+			Expect(err).To(Succeed())
+			rules, err := slo.GenerateMetadataRecordingRules(ctx, sampleSLO, alertGroup)
+			Expect(err).To(Succeed())
+			// TODO : better testing for this when the final format is more stable
+			Expect(rules).To(HaveLen(7))
 		})
 
 		It("Should create valid prometheus rules", func() {

--- a/plugins/slo/pkg/slo/slo_test.go
+++ b/plugins/slo/pkg/slo/slo_test.go
@@ -282,6 +282,21 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 			Expect(rules).To(HaveLen(7))
 		})
 
+		It("Should be able to generate alert rulefmt.Rules base on alertGroups and SLO definition", func() {
+			sampleSLO := simplePrometheusIR[0].SLOs[0]
+			ctx := context.Background()
+			alertSLO := alert.SLO{
+				ID:        "foo",
+				Objective: 99.99,
+			}
+			alertGroup, err := slo.GenerateMWWBAlerts(ctx, alertSLO, time.Hour*24)
+			Expect(err).To(Succeed())
+			rules, err := slo.GenerateSLOAlertRules(ctx, sampleSLO, *alertGroup)
+			Expect(err).To(Succeed())
+			// TODO : better testing for this when the final format is more stable
+			Expect(rules).To(HaveLen(2))
+		})
+
 		It("Should create valid prometheus rules", func() {
 			var err error
 			simplePrometheusResponse, err = slo.GeneratePrometheusRule(simplePrometheusIR, context.Background())

--- a/plugins/slo/pkg/slo/slo_test.go
+++ b/plugins/slo/pkg/slo/slo_test.go
@@ -9,7 +9,6 @@ import (
 
 	oslov1 "github.com/alexandreLamarre/oslo/pkg/manifest/v1"
 	"github.com/alexandreLamarre/sloth/core/alert"
-	"github.com/alexandreLamarre/sloth/core/app/generate"
 	"github.com/alexandreLamarre/sloth/core/prometheus"
 	"github.com/hashicorp/go-hclog"
 	. "github.com/onsi/ginkgo/v2"
@@ -87,11 +86,11 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 	// var alertPrometheusIR []*prometheus.SLOGroup
 	// var multiAlertPrometheusIR []*prometheus.SLOGroup
 
-	var simplePrometheusResponse []*generate.Response
-	var objectivePrometheusResponse []*generate.Response
-	var multiClusterPrometheusResponse []*generate.Response
-	// var alertPrometheusIR []*generate.Response
-	// var multiAlertPrometheusIR []*generate.Response
+	var simplePrometheusResponse []slo.SLORuleFmtWrapper
+	var objectivePrometheusResponse []slo.SLORuleFmtWrapper
+	var multiClusterPrometheusResponse []slo.SLORuleFmtWrapper
+	// var alertPrometheusIR []slo.SLORuleFmtWrapper
+	// var multiAlertPrometheusIR []slo.SLORuleFmtWrapper
 
 	When("A ServiceLevelObjective message is given", func() {
 		It("should validate proper input", func() {
@@ -299,17 +298,27 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 
 		It("Should create valid prometheus rules", func() {
 			var err error
-			simplePrometheusResponse, err = slo.GeneratePrometheusRule(simplePrometheusIR, context.Background())
-			Expect(err).To(MatchError("Prometheus generator failed to start"))
-			Expect(simplePrometheusResponse).To(BeNil())
 
-			objectivePrometheusResponse, err = slo.GeneratePrometheusRule(objectivePrometheusIR, context.Background())
-			Expect(err).To(MatchError("Prometheus generator failed to start"))
-			Expect(objectivePrometheusResponse).To(BeNil())
+			for _, sloGroup := range simplePrometheusIR {
+				simplePrometheusResponse, err = slo.GeneratePrometheusNoSlothGenerator(sloGroup, context.Background(), hclog.New(&hclog.LoggerOptions{}))
+				Expect(err).To(Succeed())
+				// TODO : better testing for this when the final format is more stable
+				Expect(len(simplePrometheusResponse)).Should(BeNumerically(">=", 1))
+			}
 
-			multiClusterPrometheusResponse, err = slo.GeneratePrometheusRule(multiClusterPrometheusIR, context.Background())
-			Expect(err).To(MatchError("Prometheus generator failed to start"))
-			Expect(multiClusterPrometheusResponse).To(BeNil())
+			for _, sloGroup := range objectivePrometheusIR {
+				objectivePrometheusResponse, err = slo.GeneratePrometheusNoSlothGenerator(sloGroup, context.Background(), hclog.New(&hclog.LoggerOptions{}))
+				Expect(err).To(Succeed())
+				// TODO : better testing for this when the final format is more stable
+				Expect(len(objectivePrometheusResponse)).Should(BeNumerically(">=", 1))
+			}
+
+			for _, sloGroup := range multiClusterPrometheusIR {
+				multiClusterPrometheusResponse, err = slo.GeneratePrometheusNoSlothGenerator(sloGroup, context.Background(), hclog.New(&hclog.LoggerOptions{}))
+				Expect(err).To(Succeed())
+				// TODO : better testing for this when the final format is more stable
+				Expect(len(multiClusterPrometheusResponse)).Should(BeNumerically(">=", 1))
+			}
 		})
 	})
 

--- a/plugins/slo/pkg/slo/slo_test.go
+++ b/plugins/slo/pkg/slo/slo_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	oslov1 "github.com/alexandreLamarre/oslo/pkg/manifest/v1"
+	"github.com/alexandreLamarre/sloth/core/alert"
 	"github.com/alexandreLamarre/sloth/core/app/generate"
 	"github.com/alexandreLamarre/sloth/core/prometheus"
 	"github.com/hashicorp/go-hclog"
@@ -237,6 +239,16 @@ var _ = Describe("Converting ServiceLevelObjective Messages to Prometheus Rules"
 	})
 
 	When("We convert Sloth IR to prometheus rules", func() {
+		It("Should create valid MWMB rates", func() {
+			var err error
+			alertSLO := alert.SLO{
+				ID:        "foo",
+				Objective: 99.99,
+			}
+			ctx := context.Background()
+			_, err = slo.GenerateMWWBAlerts(ctx, alertSLO, time.Hour*24)
+			Expect(err).To(HaveOccurred())
+		})
 		It("Should create valid prometheus rules", func() {
 			var err error
 			simplePrometheusResponse, err = slo.GeneratePrometheusRule(simplePrometheusIR, context.Background())

--- a/plugins/slo/pkg/slo/util.go
+++ b/plugins/slo/pkg/slo/util.go
@@ -11,12 +11,14 @@ const (
 	tplKeyWindow = "window"
 )
 
+/// Reference : https://github.com/slok/sloth/blob/eddd8145a696c3dc6d423e9d50cdb906186a52a3/internal/prometheus/recording_rules.go#L308
 var burnRateRecordingExprTpl = template.Must(template.New("burnRateExpr").Option("missingkey=error").Parse(`{{ .SLIErrorMetric }}{{ .MetricFilter }}
 / on({{ .SLOIDName }}, {{ .SLOLabelName }}, {{ .SLOServiceName }}) group_left
 {{ .ErrorBudgetRatioMetric }}{{ .MetricFilter }}
 `))
 
-// Multiburn multiwindow alert template.
+/// Reference : https://github.com/slok/sloth/blob/2de193572284e36189fe78ab33beb7e2b339b0f8/internal/prometheus/alert_rules.go#L109
+/// Multiburn multiwindow alert template.
 var mwmbAlertTpl = template.Must(template.New("mwmbAlertTpl").Option("missingkey=error").Parse(`(
     max({{ .QuickShortMetric }}{{ .MetricFilter}} > ({{ .QuickShortBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
     and

--- a/plugins/slo/pkg/slo/util.go
+++ b/plugins/slo/pkg/slo/util.go
@@ -16,6 +16,20 @@ var burnRateRecordingExprTpl = template.Must(template.New("burnRateExpr").Option
 {{ .ErrorBudgetRatioMetric }}{{ .MetricFilter }}
 `))
 
+// Multiburn multiwindow alert template.
+var mwmbAlertTpl = template.Must(template.New("mwmbAlertTpl").Option("missingkey=error").Parse(`(
+    max({{ .QuickShortMetric }}{{ .MetricFilter}} > ({{ .QuickShortBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+    and
+    max({{ .QuickLongMetric }}{{ .MetricFilter}} > ({{ .QuickLongBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+)
+or
+(
+    max({{ .SlowShortMetric }}{{ .MetricFilter }} > ({{ .SlowShortBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+    and
+    max({{ .SlowQuickMetric }}{{ .MetricFilter }} > ({{ .SlowQuickBurnFactor }} * {{ .ErrorBudgetRatio }})) without ({{ .WindowLabel }})
+)
+`))
+
 // Pretty simple durations for prometheus.
 func timeDurationToPromStr(t time.Duration) string {
 	return prommodel.Duration(t).String()

--- a/plugins/slo/pkg/slo/util.go
+++ b/plugins/slo/pkg/slo/util.go
@@ -1,0 +1,41 @@
+package slo
+
+import (
+	"html/template"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+)
+
+const (
+	tplKeyWindow = "window"
+)
+
+var burnRateRecordingExprTpl = template.Must(template.New("burnRateExpr").Option("missingkey=error").Parse(`{{ .SLIErrorMetric }}{{ .MetricFilter }}
+/ on({{ .SLOIDName }}, {{ .SLOLabelName }}, {{ .SLOServiceName }}) group_left
+{{ .ErrorBudgetRatioMetric }}{{ .MetricFilter }}
+`))
+
+// Pretty simple durations for prometheus.
+func timeDurationToPromStr(t time.Duration) string {
+	return prommodel.Duration(t).String()
+}
+
+func MergeLabels(ms ...map[string]string) map[string]string {
+	res := map[string]string{}
+	for _, m := range ms {
+		for k, v := range m {
+			res[k] = v
+		}
+	}
+	return res
+}
+
+func labelsToPromFilter(labels map[string]string) string {
+	metricFilters := prommodel.LabelSet{}
+	for k, v := range labels {
+		metricFilters[prommodel.LabelName(k)] = prommodel.LabelValue(v)
+	}
+
+	return metricFilters.String()
+}

--- a/plugins/slo/pkg/slo/window.go
+++ b/plugins/slo/pkg/slo/window.go
@@ -1,0 +1,130 @@
+package slo
+
+import (
+	"fmt"
+	"time"
+)
+
+type Windows struct {
+	SLOPeriod   time.Duration
+	PageQuick   Window
+	PageSlow    Window
+	TicketQuick Window
+	TicketSlow  Window
+}
+
+//FIXME: set this to sensible defaults
+func WindowDefaults(period time.Duration) *Windows {
+	return &Windows{
+		SLOPeriod: period,
+		PageQuick: Window{
+			LongWindow:         time.Minute * 30,
+			ShortWindow:        time.Minute * 2,
+			ErrorBudgetPercent: 2,
+		},
+		PageSlow: Window{
+			LongWindow:         time.Minute * 60,
+			ShortWindow:        time.Minute * 5,
+			ErrorBudgetPercent: 5,
+		},
+		TicketQuick: Window{
+			LongWindow:         period,
+			ShortWindow:        period,
+			ErrorBudgetPercent: 10,
+		},
+		TicketSlow: Window{
+			LongWindow:         period,
+			ShortWindow:        period,
+			ErrorBudgetPercent: 10,
+		},
+	}
+}
+
+type Window struct {
+	// ErrorBudgetPercent is the error budget % consumed for a full time window.
+	// Google gives us some defaults in its SRE workbook that work correctly most of the times:
+	// - Page quick:   2%
+	// - Page slow:    5%
+	// - Ticket quick: 10%
+	// - Ticket slow:  10%
+	ErrorBudgetPercent float64
+	// ShortWindow is the small window used on the alerting part to stop alerting
+	// during a long window because we consumed a lot of error budget but the problem
+	// is already gone.
+	ShortWindow time.Duration
+	// LongWindow is the long window used to alert based on the errors happened on that
+	// long window.
+	LongWindow time.Duration
+}
+
+func (w Window) Validate() error {
+	if w.LongWindow == 0 {
+		return fmt.Errorf("long window is required")
+	}
+
+	if w.ShortWindow == 0 {
+		return fmt.Errorf("short window is required")
+	}
+
+	if w.ErrorBudgetPercent == 0 {
+		return fmt.Errorf("error budget is required")
+	}
+
+	return nil
+}
+
+func (w Windows) Validate() error {
+	if w.SLOPeriod == 0 {
+		return fmt.Errorf("slo period is required")
+	}
+
+	err := w.PageQuick.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid page quick: %w", err)
+	}
+
+	err = w.PageSlow.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid page slow: %w", err)
+	}
+
+	err = w.TicketQuick.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid ticket quick: %w", err)
+	}
+
+	err = w.TicketSlow.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid ticket slow: %w", err)
+	}
+
+	return nil
+}
+
+// Error budget speeds based on a full time window, however once we have the factor (speed)
+// the value can be used with any time window.
+func (w Windows) GetSpeedPageQuick() float64 {
+	return w.GetBurnRateFactor(w.SLOPeriod, float64(w.PageQuick.ErrorBudgetPercent), w.PageQuick.LongWindow)
+}
+func (w Windows) GetSpeedPageSlow() float64 {
+	return w.GetBurnRateFactor(w.SLOPeriod, float64(w.PageSlow.ErrorBudgetPercent), w.PageSlow.LongWindow)
+}
+func (w Windows) GetSpeedTicketQuick() float64 {
+	return w.GetBurnRateFactor(w.SLOPeriod, float64(w.TicketQuick.ErrorBudgetPercent), w.TicketQuick.LongWindow)
+}
+func (w Windows) GetSpeedTicketSlow() float64 {
+	return w.GetBurnRateFactor(w.SLOPeriod, float64(w.TicketSlow.ErrorBudgetPercent), w.TicketSlow.LongWindow)
+}
+
+// getBurnRateFactor calculates the burnRateFactor (speed) needed to consume all the error budget available percent
+// in a specific time window taking into account the total time window.
+func (w Windows) GetBurnRateFactor(totalWindow time.Duration, errorBudgetPercent float64, consumptionWindow time.Duration) float64 {
+	// First get the total hours required to consume the % of the error budget in the total window.
+	hoursRequiredConsumption := errorBudgetPercent * totalWindow.Hours() / 100
+
+	// Now calculate how much is the factor required for the hours consumption, in case we would need to use
+	// a different time window (e.g: hours required: 36h, if we want to do it in 6h: would be `x6`).
+	speed := hoursRequiredConsumption / consumptionWindow.Hours()
+
+	return speed
+}

--- a/plugins/slo/pkg/slo/window.go
+++ b/plugins/slo/pkg/slo/window.go
@@ -1,3 +1,4 @@
+/// Reference : https://github.dev/slok/sloth/tree/main/internal/alert/window.go
 package slo
 
 import (

--- a/plugins/slo/pkg/slo/window.go
+++ b/plugins/slo/pkg/slo/window.go
@@ -13,28 +13,28 @@ type Windows struct {
 	TicketSlow  Window
 }
 
-//FIXME: set this to sensible defaults
+//https://sre.google/workbook/alerting-on-slos/
 func WindowDefaults(period time.Duration) *Windows {
 	return &Windows{
 		SLOPeriod: period,
 		PageQuick: Window{
-			LongWindow:         time.Minute * 30,
-			ShortWindow:        time.Minute * 2,
+			LongWindow:         time.Minute * 60,
+			ShortWindow:        time.Minute * 5,
 			ErrorBudgetPercent: 2,
 		},
 		PageSlow: Window{
-			LongWindow:         time.Minute * 60,
-			ShortWindow:        time.Minute * 5,
+			LongWindow:         time.Hour * 6,
+			ShortWindow:        time.Minute * 30,
 			ErrorBudgetPercent: 5,
 		},
 		TicketQuick: Window{
-			LongWindow:         period,
-			ShortWindow:        period,
+			LongWindow:         (time.Hour * 24) * 3,
+			ShortWindow:        time.Hour * 6,
 			ErrorBudgetPercent: 10,
 		},
 		TicketSlow: Window{
-			LongWindow:         period,
-			ShortWindow:        period,
+			LongWindow:         (time.Hour * 24) * 3,
+			ShortWindow:        time.Hour * 6,
 			ErrorBudgetPercent: 10,
 		},
 	}


### PR DESCRIPTION
Fixing sloth in the best way possible : removing sloth (kind of)

Once I started trying to generate alerts with sloth + my custom OpenSLO v1 format IR, I realized using the sloth generators weren't going to work at all for our use-case.

1) they are tied to OO where the methods are predicated on reading from the filesystem
2) Confusing function factories and factory configs which were tied to very specific yaml input formats

In essence, I stripped the sloth generator down to the basics and repurposed the raw core functions into the plugin package `plugins/slo/pkg/slo` so we can have more control over how to generate alerts & recording rules