### PR TITLE
Fix upgrade responder and add extra info

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -182,12 +182,6 @@ func init() {
 	}
 
 	// get version info
-	dirty := true
-	if output, err := sh.Output("git", "status", "--porcelain", "--untracked-files=no"); err != nil {
-		panic(err)
-	} else if strings.TrimSpace(output) == "" {
-		dirty = false
-	}
 	var tag string
 	if droneTag, ok := os.LookupEnv("DRONE_TAG"); ok {
 		tag = droneTag
@@ -199,8 +193,8 @@ func init() {
 	}
 	tag = strings.TrimSpace(tag)
 
-	version := "dev"
-	if !dirty && tag != "" {
+	version := "unversioned"
+	if tag != "" {
 		version = tag
 	}
 

--- a/pkg/opni/commands/manager.go
+++ b/pkg/opni/commands/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/opni/apis/v1beta2"
 	"github.com/rancher/opni/controllers"
 	"github.com/rancher/opni/pkg/features"
+	"github.com/rancher/opni/pkg/opni/common"
 	"github.com/rancher/opni/pkg/tracing"
 	"github.com/rancher/opni/pkg/util"
 	"github.com/rancher/opni/pkg/util/manager"
@@ -80,10 +81,13 @@ func BuildManagerCmd() *cobra.Command {
 				return err
 			}
 
-			if !disableUsage && Version != "dev" {
-				upgradeRequester := manager.UpgradeRequester{Version: Version}
+			if !(disableUsage || common.DisableUsage) {
+				upgradeRequester := manager.UpgradeRequester{
+					Version:     util.Version,
+					InstallType: manager.InstallTypeManager,
+				}
 				upgradeRequester.SetupLoggerWithManager(mgr)
-				setupLog.Info("Usage tracking enabled", "current-version", Version)
+				setupLog.Info("Usage tracking enabled", "current-version", util.Version)
 				upgradeChecker := upgraderesponder.NewUpgradeChecker(upgradeResponderAddress, &upgradeRequester)
 				upgradeChecker.Start()
 				defer upgradeChecker.Stop()
@@ -237,7 +241,6 @@ func BuildManagerCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	cmd.Flags().BoolVar(&disableUsage, "disable-usage", false, "Disable anonymous Opni usage tracking.")
 	cmd.Flags().BoolVarP(&echoVersion, "version", "v", false, "print the version and exit")
 	features.DefaultMutableFeatureGate.AddFlag(cmd.Flags())
 

--- a/pkg/opni/commands/version.go
+++ b/pkg/opni/commands/version.go
@@ -26,7 +26,7 @@ func BuildVersionCmd() *cobra.Command {
 			})
 			var noun string
 			var version string
-			if util.Version == "dev" {
+			if util.Version == "unversioned" {
 				noun = "revision"
 				version = settings["vcs.revision"].Value
 			} else {

--- a/pkg/opni/common/options.go
+++ b/pkg/opni/common/options.go
@@ -20,6 +20,7 @@ var (
 	NamespaceFlagValue       string
 	ContextOverrideFlagValue string
 	ExplicitPathFlagValue    string
+	DisableUsage             bool
 	K8sClient                client.Client
 	RestConfig               *rest.Config
 	APIConfig                *api.Config

--- a/pkg/opni/root.go
+++ b/pkg/opni/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/opni/pkg/logger"
 	"github.com/rancher/opni/pkg/opni/commands"
+	"github.com/rancher/opni/pkg/opni/common"
 
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,9 @@ func BuildRootCmd() *cobra.Command {
 	rootCmd.AddCommand(commands.BuildRealtimeCmd())
 	rootCmd.AddCommand(commands.BuildEventsCmd())
 	rootCmd.AddCommand(commands.BuildHooksCmd())
+
+	rootCmd.PersistentFlags().BoolVar(&common.DisableUsage, "disable-usage", false, "Disable anonymous Opni usage tracking.")
+
 	return rootCmd
 }
 

--- a/pkg/util/manager/upgrade_requester.go
+++ b/pkg/util/manager/upgrade_requester.go
@@ -11,7 +11,15 @@ const (
 	VersionTagLatest = "latest"
 )
 
+type InstallType string
+
+const (
+	InstallTypeManager InstallType = "manager"
+	InstallTypeAgent   InstallType = "agent"
+)
+
 type UpgradeRequester struct {
+	InstallType
 	Version string
 	log     logr.Logger
 }
@@ -20,12 +28,18 @@ func (r *UpgradeRequester) SetupLoggerWithManager(mgr ctrl.Manager) {
 	r.log = mgr.GetLogger().WithName("upgrade-check")
 }
 
+func (r *UpgradeRequester) SetupLogger(logger logr.Logger) {
+	r.log = logger.WithName("upgrade-check")
+}
+
 func (r *UpgradeRequester) GetCurrentVersion() string {
 	return r.Version
 }
 
 func (r *UpgradeRequester) GetExtraInfo() map[string]string {
-	return map[string]string{}
+	return map[string]string{
+		"installType": string(r.InstallType),
+	}
 }
 
 func (r *UpgradeRequester) ProcessUpgradeResponse(response *upgraderesponder.CheckUpgradeResponse, err error) {


### PR DESCRIPTION
PR make the following changes:
 - Removed the dirty repo checks for versioning because they fail when running in the dagger environment.
 - Moved disable usage to a global persistent flag.
 - Added upgrade responder to the agent, and added extra info to differentiate the two.

Fixes #392 