### PR TITLE
Update publish version tag for opensearch updating service image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -217,6 +217,7 @@ steps:
         from_secret: docker_password
       TWINE_PASSWORD:
         from_secret: twine_password
+      TAG: ${DRONE_TAG}
     commands:
       - bin/dagger do aiops
     volumes: *volumes


### PR DESCRIPTION
This PR updates the publish version tag for the opni-opensearch-update-service image for RC 6.