### PR TITLE
Check for nil pointer in gw.Spec.Alerting

### DIFF
--- a/pkg/resources/gateway/configmap.go
+++ b/pkg/resources/gateway/configmap.go
@@ -44,14 +44,19 @@ func (r *Reconciler) configMap() (resources.Resource, error) {
 			Storage: cfgv1beta1.StorageSpec{
 				Type: r.gw.Spec.StorageType,
 			},
-			Alerting: cfgv1beta1.AlertingSpec{
-				Endpoints: []string{
-					fmt.Sprintf("opni-alerting:%d", r.gw.Spec.Alerting.Port),
-				},
-			},
 		},
 	}
 	gatewayConf.Spec.SetDefaults()
+
+	if r.gw.Spec.Alerting == nil {
+		gatewayConf.Spec.Alerting = cfgv1beta1.AlertingSpec{
+			Endpoints: []string{"opni-alerting:9093"},
+		}
+	} else {
+		gatewayConf.Spec.Alerting = cfgv1beta1.AlertingSpec{
+			Endpoints: []string{fmt.Sprintf("opni-alerting:%d", r.gw.Spec.Alerting.Port)},
+		}
+	}
 
 	switch r.gw.Spec.StorageType {
 	case cfgv1beta1.StorageTypeEtcd:

--- a/pkg/resources/gateway/configmap.go
+++ b/pkg/resources/gateway/configmap.go
@@ -44,19 +44,19 @@ func (r *Reconciler) configMap() (resources.Resource, error) {
 			Storage: cfgv1beta1.StorageSpec{
 				Type: r.gw.Spec.StorageType,
 			},
+			Alerting: func() cfgv1beta1.AlertingSpec {
+				if r.gw.Spec.Alerting == nil {
+					return cfgv1beta1.AlertingSpec{
+						Endpoints: []string{"opni-alerting:9093"},
+					}
+				}
+				return cfgv1beta1.AlertingSpec{
+					Endpoints: []string{fmt.Sprintf("opni-alerting:%d", r.gw.Spec.Alerting.Port)},
+				}
+			}(),
 		},
 	}
 	gatewayConf.Spec.SetDefaults()
-
-	if r.gw.Spec.Alerting == nil {
-		gatewayConf.Spec.Alerting = cfgv1beta1.AlertingSpec{
-			Endpoints: []string{"opni-alerting:9093"},
-		}
-	} else {
-		gatewayConf.Spec.Alerting = cfgv1beta1.AlertingSpec{
-			Endpoints: []string{fmt.Sprintf("opni-alerting:%d", r.gw.Spec.Alerting.Port)},
-		}
-	}
 
 	switch r.gw.Spec.StorageType {
 	case cfgv1beta1.StorageTypeEtcd:


### PR DESCRIPTION
in `resources/gateway/configmap.go`, need to check for r.gw.Spec.Alerting is nil, since we decided to specify that part of the spec as optional (and therefore as a pointer)