### PR TITLE
Fix reconciler error with correct ns name

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
           image: controller
           name: manager
           env:
-            - name: OPNI_SYSTEM_NAMESPACE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/pkg/resources/gateway/alerting.go
+++ b/pkg/resources/gateway/alerting.go
@@ -22,7 +22,7 @@ func (r *Reconciler) alerting() []resources.Resource {
 		}
 	}
 
-	publicLabels := resources.NewGatewayLabels()
+	publicLabels := map[string]string{} // TODO define a set of meaningful labels for this service
 	labelWithAlert := func(label map[string]string) map[string]string {
 		label["app"] = "opni-alerting"
 		return label
@@ -92,7 +92,6 @@ func (r *Reconciler) alerting() []resources.Resource {
 	ctrl.SetControllerReference(r.gw, deploy, r.client.Scheme())
 
 	publicSvcLabels := publicLabels
-	publicSvcLabels["service-type"] = "public"
 
 	alertingSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/gateway/alerting.go
+++ b/pkg/resources/gateway/alerting.go
@@ -24,7 +24,7 @@ func (r *Reconciler) alerting() []resources.Resource {
 
 	publicLabels := map[string]string{} // TODO define a set of meaningful labels for this service
 	labelWithAlert := func(label map[string]string) map[string]string {
-		label["app"] = "opni-alerting"
+		label["app.kubernetes.io/name"] = "opni-alerting"
 		return label
 	}
 	publicLabels = labelWithAlert(publicLabels)

--- a/pkg/resources/gateway/deployment.go
+++ b/pkg/resources/gateway/deployment.go
@@ -47,7 +47,7 @@ func (r *Reconciler) deployment() (resources.Resource, error) {
 							Args:            []string{"gateway"},
 							Env: func() []corev1.EnvVar {
 								return append(r.gw.Spec.ExtraEnvVars, corev1.EnvVar{
-									Name: "OPNI_SYSTEM_NAMESPACE",
+									Name: "POD_NAMESPACE",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.namespace",

--- a/plugins/logging/pkg/logging/plugin.go
+++ b/plugins/logging/pkg/logging/plugin.go
@@ -99,7 +99,7 @@ func NewPlugin(ctx context.Context, opts ...PluginOption) *Plugin {
 func Scheme(ctx context.Context) meta.Scheme {
 	scheme := meta.NewScheme()
 
-	ns := os.Getenv("OPNI_SYSTEM_NAMESPACE")
+	ns := os.Getenv("POD_NAMESPACE")
 
 	opniCluster := &opnimeta.OpensearchClusterRef{
 		Name:      "opni",


### PR DESCRIPTION
couple of `OPNI_SYSTEM_NAMESPACE` env var were still in use, when  we made the change for opni-manager to use `POD_NAMESPACE` they were leftover

See https://github.com/rancher/opni/pull/327 & https://github.com/rancher/opni/issues/317 