### PR TITLE
Update monitoring installer template

### DIFF
--- a/pkg/capabilities/store.go
+++ b/pkg/capabilities/store.go
@@ -74,10 +74,15 @@ func (s *backendStore) RenderInstaller(name string, spec UserInstallerTemplateSp
 	if err != nil {
 		return "", err
 	}
-	return RenderInstallerCommand(backend.InstallerTemplate(), InstallerTemplateSpec{
+	templateSpec := InstallerTemplateSpec{
 		UserInstallerTemplateSpec:   spec,
 		ServerInstallerTemplateSpec: s.serverSpec,
-	})
+	}
+	result, err := RenderInstallerCommand(backend.InstallerTemplate(), templateSpec)
+	if err != nil {
+		return "", err
+	}
+	return RenderInstallerCommand(result, templateSpec)
 }
 
 func (s *backendStore) CanInstall(capabilities ...string) error {

--- a/pkg/capabilities/store_test.go
+++ b/pkg/capabilities/store_test.go
@@ -104,7 +104,9 @@ var _ = Describe("Store", Ordered, Label("unit"), func() {
 					InstallerTemplate: template,
 				}))).To(Succeed())
 
-				installer, err := store.RenderInstaller("capability", capabilities.UserInstallerTemplateSpec{})
+				installer, err := store.RenderInstaller("capability", capabilities.UserInstallerTemplateSpec{
+					Token: "foo",
+				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(installer).To(Equal(expected))
 			},
@@ -113,6 +115,7 @@ var _ = Describe("Store", Ordered, Label("unit"), func() {
 			Entry(nil, `{{ arg "select" "test" "item1" "item2" "item3" }}`, `%{"kind":"select","select":{"label":"test","items":["item1","item2","item3"]}}%`),
 			Entry(nil, `{{ arg "select" "test" "item1" "item2" "item3" "+required" "+omitEmpty" "+default:foo" "+format:{{value}}" }}`, `%{"kind":"select","select":{"label":"test","items":["item1","item2","item3"]},"options":[{"name":"required"},{"name":"omitEmpty"},{"name":"default","value":"foo"},{"name":"format","value":"{{value}}"}]}%`),
 			Entry(nil, `{{ arg "toggle" "test" "+default:true" }}`, `%{"kind":"toggle","toggle":{"label":"test"},"options":[{"name":"default","value":"true"}]}%`),
+			Entry(nil, `{{ arg "toggle" "test" "+omitEmpty" "+default:{{ .Token }}" }}`, `%{"kind":"toggle","toggle":{"label":"test"},"options":[{"name":"omitEmpty"},{"name":"default","value":"foo"}]}%`),
 		)
 
 		When("the backend does not exist", func() {

--- a/pkg/capabilities/template.go
+++ b/pkg/capabilities/template.go
@@ -22,6 +22,7 @@ type UserInstallerTemplateSpec struct {
 
 type ServerInstallerTemplateSpec struct {
 	Address string
+	Port    string
 }
 
 var installerTemplate *template.Template
@@ -29,6 +30,9 @@ var installerTemplate *template.Template
 func init() {
 	fm := sprig.TxtFuncMap()
 	fm["arg"] = Arg
+	fm["value"] = func() string {
+		return "{{value}}"
+	}
 	installerTemplate = template.New("installer").Funcs(fm)
 }
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/tls"
+	"fmt"
 	"net"
 
 	"github.com/hashicorp/go-plugin"
@@ -106,7 +107,8 @@ func NewGateway(ctx context.Context, conf *config.GatewayConfig, pl plugins.Load
 		).Fatal("failed to parse listen address")
 	}
 	capBackendStore := capabilities.NewBackendStore(capabilities.ServerInstallerTemplateSpec{
-		Address: "https://" + conf.Spec.Hostname + ":" + port,
+		Address: conf.Spec.Hostname,
+		Port:    fmt.Sprint(port),
 	}, lg)
 
 	// add capabilities from plugins

--- a/plugins/cortex/pkg/cortex/capability.go
+++ b/plugins/cortex/pkg/cortex/capability.go
@@ -15,10 +15,10 @@ func (p *Plugin) Uninstall(clustre *corev1.Reference) error {
 }
 
 func (p *Plugin) InstallerTemplate() string {
-	return `helm install opni-monitoring-agent ` +
-		`{{ arg "input" "Namespace" "+omitEmpty" "+default:opni-monitoring-agent" "+format:-n {{ value }}" }} ` +
-		`oci://ghcr.io/kralicky/helm/opni-monitoring-agent --version=0.4.1 ` +
-		`--set "token={{ .Token }},pin={{ .Pin }},address={{ .Address }}" ` +
+	return `helm install opni-agent ` +
+		`{{ arg "input" "Namespace" "+omitEmpty" "+default:opni-agent" "+format:-n {{ value }}" }} ` +
+		`oci://docker.io/rancher/opni-helm --version=0.5.4 ` +
+		`--set monitoring.enabled=true,token={{ .Token }},pin={{ .Pin }},address={{ arg "input" "Gateway Hostname" "+default:{{ .Address }}" }}:{{ arg "input" "Gateway Port" "+default:{{ .Port }}" }} ` +
 		`{{ arg "toggle" "Install Prometheus Operator" "+omitEmpty" "+default:false" "+format:--set kube-prometheus-stack.enabled={{ value }}" }} ` +
 		`--create-namespace`
 }


### PR DESCRIPTION
- Update monitoring installer template to allow hostname and port override options in the UI
- Allow one level of installer template recursion

Closes #408 