### PR TITLE
Opensearch template index

### DIFF
--- a/pkg/resources/opnicluster/elastic/indices/indices.go
+++ b/pkg/resources/opnicluster/elastic/indices/indices.go
@@ -171,6 +171,7 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 		}
 		policies = append(policies, opniDrainModelStatusPolicy)
 		policies = append(policies, opniMetricPolicy)
+		policies = append(policies, opniLogTemplatePolicy)
 	}
 	for _, policy := range policies {
 		err = r.osReconciler.ReconcileISM(policy)
@@ -193,6 +194,7 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 	templates := []esapiext.IndexTemplateSpec{
 		drainStatusTemplate,
 		opniMetricTemplate,
+		logTemplate,
 	}
 
 	if lo.FromPtrOr(r.cluster.Spec.Opensearch.EnableLogIndexManagement, true) {
@@ -244,6 +246,7 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 	prefixes := map[string]string{
 		drainStatusIndexPrefix: drainStatusIndexAlias,
 		metricIndexPrefix:      metricIndexAlias,
+		logTemplateIndexPrefix: logTemplateIndexAlias,
 	}
 
 	if lo.FromPtrOr(r.cluster.Spec.Opensearch.EnableLogIndexManagement, true) {

--- a/pkg/resources/opnicluster/elastic/indices/indices.go
+++ b/pkg/resources/opnicluster/elastic/indices/indices.go
@@ -171,7 +171,6 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 		}
 		policies = append(policies, opniDrainModelStatusPolicy)
 		policies = append(policies, opniMetricPolicy)
-		policies = append(policies, opniLogTemplatePolicy)
 	}
 	for _, policy := range policies {
 		err = r.osReconciler.ReconcileISM(policy)
@@ -194,7 +193,6 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 	templates := []esapiext.IndexTemplateSpec{
 		drainStatusTemplate,
 		opniMetricTemplate,
-		logTemplate,
 	}
 
 	if lo.FromPtrOr(r.cluster.Spec.Opensearch.EnableLogIndexManagement, true) {
@@ -246,7 +244,6 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 	prefixes := map[string]string{
 		drainStatusIndexPrefix: drainStatusIndexAlias,
 		metricIndexPrefix:      metricIndexAlias,
-		logTemplateIndexPrefix: logTemplateIndexAlias,
 	}
 
 	if lo.FromPtrOr(r.cluster.Spec.Opensearch.EnableLogIndexManagement, true) {
@@ -260,6 +257,12 @@ func (r *Reconciler) Reconcile() (retResult *reconcile.Result, retErr error) {
 			retErr = errors.Combine(retErr, err)
 			return
 		}
+	}
+
+	err = r.osReconciler.MaybeCreateIndex(logTemplateIndexName, logTemplateIndexSettings)
+	if err != nil {
+		conditions = append(conditions, err.Error())
+		retErr = errors.Combine(retErr, err)
 	}
 
 	err = r.osReconciler.MaybeCreateIndex(normalIntervalIndexName, normalIntervalIndexSettings)

--- a/pkg/resources/opnicluster/elastic/indices/opni_settings.go
+++ b/pkg/resources/opnicluster/elastic/indices/opni_settings.go
@@ -878,7 +878,7 @@ var (
 					},
 					"template_matched": {
 						Type: "keyword",
-					}
+					},
 					"template_cluster_id": {
 						Type: "integer",
 					},

--- a/pkg/resources/opnicluster/elastic/indices/opni_settings.go
+++ b/pkg/resources/opnicluster/elastic/indices/opni_settings.go
@@ -762,7 +762,7 @@ var (
 				},
 				"template_cluster_id": {
 					Type: "integer",
-				}
+				},
 			},
 		},
 	}

--- a/pkg/resources/opnicluster/elastic/indices/opni_settings.go
+++ b/pkg/resources/opnicluster/elastic/indices/opni_settings.go
@@ -874,10 +874,10 @@ var (
 			Mappings: osapiext.TemplateMappingsSpec{
 				Properties: map[string]osapiext.PropertySettings{
 					"log": {
-						Type: "text"
+						Type: "text",
 					},
 					"template_matched": {
-						Type: "keyword"
+						Type: "keyword",
 					}
 					"template_cluster_id": {
 						Type: "integer",

--- a/pkg/resources/opnicluster/elastic/indices/opni_settings.go
+++ b/pkg/resources/opnicluster/elastic/indices/opni_settings.go
@@ -13,10 +13,7 @@ const (
 	LogIndexPrefix               = "logs-v0.5.4"
 	LogIndexAlias                = "logs"
 	LogIndexTemplateName         = "logs_rollover_mapping"
-	logTemplatePolicyName        = "template-policy"
-	logTemplateIndexPrefix       = "templates-v0.5.4"
-	logTemplateIndexAlias        = "templates"
-	logTemplateIndexTemplateName = "templates_rollover_mapping"
+	logTemplateIndexName        = "templates"
 	PreProcessingPipelineName    = "opni-ingest-pipeline"
 	drainStatusPolicyName        = "opni-drain-model-status-policy"
 	drainStatusIndexPrefix       = "opni-drain-model-status-v0.1.3"
@@ -237,111 +234,6 @@ var (
 				fmt.Sprintf("%s*", LogIndexPrefix),
 			},
 			Priority: 100,
-		},
-	}
-	opniLogTemplatePolicy = osapiext.ISMPolicySpec{
-		ISMPolicyIDSpec: &osapiext.ISMPolicyIDSpec{
-			PolicyID:   logTemplatePolicyName,
-			MarshallID: false,
-		},
-		Description:  "A hot-warm-cold-delete workflow for the templates index.",
-		DefaultState: "hot",
-		States: []osapiext.StateSpec{
-			{
-				Name: "hot",
-				Actions: []osapiext.ActionSpec{
-					{
-						ActionOperation: &osapiext.ActionOperation{
-							Rollover: &osapiext.RolloverOperation{
-								MinSize:     "1gb",
-								MinIndexAge: "1d",
-							},
-						},
-						Retry: &DefaultRetry,
-					},
-				},
-				Transitions: []osapiext.TransitionSpec{
-					{
-						StateName: "warm",
-					},
-				},
-			},
-			{
-				Name: "warm",
-				Actions: []osapiext.ActionSpec{
-					{
-						ActionOperation: &osapiext.ActionOperation{
-							ReplicaCount: &osapiext.ReplicaCountOperation{
-								NumberOfReplicas: 0,
-							},
-						},
-						Retry: &DefaultRetry,
-					},
-					{
-						ActionOperation: &osapiext.ActionOperation{
-							IndexPriority: &osapiext.IndexPriorityOperation{
-								Priority: 50,
-							},
-						},
-						Retry: &DefaultRetry,
-					},
-					{
-						ActionOperation: &osapiext.ActionOperation{
-							ForceMerge: &osapiext.ForceMergeOperation{
-								MaxNumSegments: 1,
-							},
-						},
-						Retry: &DefaultRetry,
-					},
-				},
-				Transitions: []osapiext.TransitionSpec{
-					{
-						StateName: "cold",
-						Conditions: &osapiext.ConditionSpec{
-							MinIndexAge: "5d",
-						},
-					},
-				},
-			},
-			{
-				Name: "cold",
-				Actions: []osapiext.ActionSpec{
-					{
-						ActionOperation: &osapiext.ActionOperation{
-							ReadOnly: &osapiext.ReadOnlyOperation{},
-						},
-						Retry: &DefaultRetry,
-					},
-				},
-				Transitions: []osapiext.TransitionSpec{
-					{
-						StateName: "delete",
-						Conditions: &osapiext.ConditionSpec{
-							MinIndexAge: "30d",
-						},
-					},
-				},
-			},
-			{
-				Name: "delete",
-				Actions: []osapiext.ActionSpec{
-					{
-						ActionOperation: &osapiext.ActionOperation{
-							Delete: &osapiext.DeleteOperation{},
-						},
-						Retry: &DefaultRetry,
-					},
-				},
-				Transitions: make([]osapiext.TransitionSpec, 0),
-			},
-		},
-		ISMTemplate: []osapiext.ISMTemplateSpec{
-			{
-				IndexPatterns: []string{
-					fmt.Sprintf("%s*", logTemplateIndexPrefix),
-				},
-				Priority: 100,
-			},
 		},
 	}
 	opniDrainModelStatusPolicy = osapiext.ISMPolicySpec{
@@ -859,30 +751,18 @@ var (
 		},
 	}
 
-	logTemplate = osapiext.IndexTemplateSpec{
-		TemplateName: logTemplateIndexTemplateName,
-		IndexPatterns: []string{
-			fmt.Sprintf("%s*", logTemplateIndexPrefix),
-		},
-		Template: osapiext.TemplateSpec{
-			Settings: osapiext.TemplateSettingsSpec{
-				NumberOfShards:   2,
-				NumberOfReplicas: 1,
-				ISMPolicyID:      logTemplatePolicyName,
-				RolloverAlias:    logTemplateIndexAlias,
-			},
-			Mappings: osapiext.TemplateMappingsSpec{
-				Properties: map[string]osapiext.PropertySettings{
-					"log": {
-						Type: "text",
-					},
-					"template_matched": {
-						Type: "keyword",
-					},
-					"template_cluster_id": {
-						Type: "integer",
-					},
+	logTemplateIndexSettings = map[string]osapiext.TemplateMappingsSpec{
+		"mappings": {
+			Properties: map[string]osapiext.PropertySettings{
+				"log": {
+					Type:   "text",
 				},
+				"template_matched": {
+					Type:   "keyword",
+				},
+				"template_cluster_id": {
+					Type: "integer",
+				}
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds logic to the Opensearch Updating Service by creating the templates index which stores the template, the template cluster ID as well as the most frequently occurring log message associated with that template. It receives this information through the Opni DRAIN service.