### PR TITLE
Upgrade totem to v1.1.0-rc6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/kralicky/kmatch v0.0.0-20220713045459-85a252b9275e
 	github.com/kralicky/ragu v1.0.0-rc3
 	github.com/kralicky/spellbook v0.0.0-20220829172922-3d415e02ee8a
-	github.com/kralicky/totem v1.1.0-rc5
+	github.com/kralicky/totem v1.1.0-rc6
 	github.com/kralicky/yaml/v3 v3.0.0-20220520012407-b0e7050bd81d
 	github.com/kubernetes-sigs/node-feature-discovery-operator v0.2.1-0.20210826163723-568b36491208
 	github.com/lestrrat-go/backoff/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -1891,6 +1891,8 @@ github.com/kralicky/totem v1.1.0-rc4.0.20221012015347-f752584b0e56 h1:a8QJIHYV09
 github.com/kralicky/totem v1.1.0-rc4.0.20221012015347-f752584b0e56/go.mod h1:l6wZ22m0hEIBML+HE0qJTwqAZMg9m9qpbRC2tCZNtqg=
 github.com/kralicky/totem v1.1.0-rc5 h1:z8a2GXQsGpA2wd5whmu81Ivxs/5Czxx87YYwNMcJEDU=
 github.com/kralicky/totem v1.1.0-rc5/go.mod h1:l6wZ22m0hEIBML+HE0qJTwqAZMg9m9qpbRC2tCZNtqg=
+github.com/kralicky/totem v1.1.0-rc6 h1:x3BH1GrdFuVbFnBAuIifpzX9VUQjagz/atlbX31XSeY=
+github.com/kralicky/totem v1.1.0-rc6/go.mod h1:l6wZ22m0hEIBML+HE0qJTwqAZMg9m9qpbRC2tCZNtqg=
 github.com/kralicky/yaml/v3 v3.0.0-20220520012407-b0e7050bd81d h1:kLfaaFdmCHKZCvL4DzQ7T9YsAVSBqZez34zaegldkls=
 github.com/kralicky/yaml/v3 v3.0.0-20220520012407-b0e7050bd81d/go.mod h1:z4cKsjE0B5RlhFSbWcZNh70UEjtwrj8fpG1QXyU2KuI=
 github.com/kralicky/zap v1.21.1-0.20220517214003-da0ae127f4db h1:OhMQACnkI4y5uEciBkaVGzPFpS/5LkPT1uHnOv84Fcw=


### PR DESCRIPTION
Includes a fix for the bug which was causing the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x38758da]
goroutine 12206 [running]:
github.com/rancher/opni/pkg/apis/control/v1.(*healthClient).GetHealth(0xc0072b3d90, {0x7aa6998, 0xc0078a9f20}, 0x0?, {0x0, 0x0, 0x0})
	/src/pkg/apis/control/v1/remote_grpc.pb.go:40 +0x9a
github.com/rancher/opni/pkg/health.(*Listener).HandleConnection(0xc0003686c0, {0x7aa6998, 0xc0078a9f20}, {0x7f07a4287ed8, 0xc006ed6c00})
	/src/pkg/health/listener.go:209 +0x69c
github.com/rancher/opni/pkg/health.(*Listener).HandleAgentConnection(0x1?, {0x7aa6998, 0xc0078a9f20}, {0x7a843a8?, 0xc006ed6c00})
	/src/pkg/health/listener.go:360 +

```