### PR TITLE
Tidy up nil pointer on removal

### DIFF
--- a/plugins/logging/pkg/agent/drivers/kubernetes/kubernetes_manager.go
+++ b/plugins/logging/pkg/agent/drivers/kubernetes/kubernetes_manager.go
@@ -177,24 +177,29 @@ BACKOFF:
 }
 
 func (m *KubernetesManagerDriver) buildAuthSecret(config *node.OpensearchConfig) *corev1.Secret {
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: m.namespace,
 		},
-		StringData: map[string]string{
-			secretKey: config.Password,
-		},
 	}
+	if config != nil {
+		secret.StringData = map[string]string{
+			secretKey: config.Password,
+		}
+	}
+	return secret
 }
 
 func (m *KubernetesManagerDriver) buildDataPrepper(config *node.OpensearchConfig) *opniloggingv1beta1.DataPrepper {
-	return &opniloggingv1beta1.DataPrepper{
+	dataPrepper := &opniloggingv1beta1.DataPrepper{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dataPrepperName,
 			Namespace: m.namespace,
 		},
-		Spec: opniloggingv1beta1.DataPrepperSpec{
+	}
+	if config != nil {
+		dataPrepper.Spec = opniloggingv1beta1.DataPrepperSpec{
 			Username: config.Username,
 			PasswordFrom: &corev1.SecretKeySelector{
 				Key: secretKey,
@@ -209,8 +214,9 @@ func (m *KubernetesManagerDriver) buildDataPrepper(config *node.OpensearchConfig
 			ClusterID:     m.clusterID,
 			EnableTracing: true,
 			Version:       dataPrepperVersion,
-		},
+		}
 	}
+	return dataPrepper
 }
 
 func (m *KubernetesManagerDriver) buildOpniClusterOutput() *loggingv1beta1.ClusterOutput {

--- a/plugins/logging/pkg/agent/node.go
+++ b/plugins/logging/pkg/agent/node.go
@@ -135,7 +135,7 @@ func (l *LoggingNode) doSync(ctx context.Context) {
 		l.logger.Info("logging node config is up to date")
 	case node.ConfigStatus_NeedsUpdate:
 		l.logger.Info("updating logging node config")
-		l.updateConfig(syncResp.UpdatedConfig)
+		l.updateConfig(syncResp.GetUpdatedConfig())
 	}
 
 	l.conditions.Clear(CondConfigSync)


### PR DESCRIPTION
If the backend doesn't exist then the opensearchConfig object will be nil.  In this case we should just create the objects with meta data so the reconcileObject function can delete them.

Fixes #697 

@AmartC FYI