### PR TITLE
Some Naive optimizations for agent memory patch performance + PatchOp_REMOVE bug fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,6 +245,7 @@ require (
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-mmap/mmap v0.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,10 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.0
+	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/go-test/deep v1.0.8
+	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.1-0.20220512030613-73266f9366fc
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.9
@@ -245,7 +247,6 @@ require (
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-mmap/mmap v0.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect
@@ -254,7 +255,6 @@ require (
 	github.com/go-openapi/loads v0.21.1 // indirect
 	github.com/go-openapi/runtime v0.23.1 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
-	github.com/go-openapi/strfmt v0.21.3 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-openapi/validate v0.21.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
@@ -268,7 +268,6 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/gogo/status v1.1.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
 	github.com/golang-migrate/migrate/v4 v4.7.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -893,6 +893,8 @@ github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNV
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
+github.com/go-mmap/mmap v0.6.0 h1:tpgojKBlJNovNKJERvoDVzd+7ziE4bObTCXen2Cq70g=
+github.com/go-mmap/mmap v0.6.0/go.mod h1:PxyWy/7uJSz/N+SPFfb93odmztcclBqqe2XN5WPXD/g=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=

--- a/go.sum
+++ b/go.sum
@@ -893,8 +893,6 @@ github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNV
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
-github.com/go-mmap/mmap v0.6.0 h1:tpgojKBlJNovNKJERvoDVzd+7ziE4bObTCXen2Cq70g=
-github.com/go-mmap/mmap v0.6.0/go.mod h1:PxyWy/7uJSz/N+SPFfb93odmztcclBqqe2XN5WPXD/g=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=

--- a/pkg/agent/v2/agent.go
+++ b/pkg/agent/v2/agent.go
@@ -415,18 +415,18 @@ func (a *Agent) syncPlugins(ctx context.Context) (_ *controlv1.ManifestMetadataL
 	// read local plugins on disk here
 	localManifests, err := patch.GetFilesystemPlugins(a.config.Plugins, a.Logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("hit an error getting filesystem plugins based on config %s", err)
 	}
 
 	patchList, err := manifestClient.SendManifestsOrKnownPatch(ctx, localManifests, grpc.UseCompressor("zstd"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("hit an error requesting plugins/patches from gateway %s", err)
 	}
 	a.Logger.Info("received patch manifest from gateway")
 
 	done, err := patch.PatchWith(ctx, a.config.Plugins, patchList, a.Logger, manifestClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("hit an error patching agent's plugins : %s", err)
 	}
 
 	go func() {
@@ -437,7 +437,7 @@ func (a *Agent) syncPlugins(ctx context.Context) (_ *controlv1.ManifestMetadataL
 	// read local manifests again
 	localManifests, err = patch.GetFilesystemPlugins(a.config.Plugins, a.Logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("filesystem plugins sanity check failed after patching : %s", err)
 	}
 
 	return localManifests, nil

--- a/pkg/apis/control/v1/msg.go
+++ b/pkg/apis/control/v1/msg.go
@@ -17,13 +17,13 @@ type PatchInfo struct {
 	OldHash   string
 }
 
-type TODOList struct {
+type PatchList struct {
 	// pluginPath to  operation
 	Items map[string]PatchInfo
 }
 
-func (m *ManifestMetadataList) LeftJoinOn(other *ManifestMetadataList) (*TODOList, error) {
-	res := &TODOList{
+func (m *ManifestMetadataList) LeftJoinOn(other *ManifestMetadataList) (*PatchList, error) {
+	res := &PatchList{
 		Items: make(map[string]PatchInfo),
 	}
 	for otherPath, _ := range other.Items {

--- a/pkg/patch/cache.go
+++ b/pkg/patch/cache.go
@@ -63,6 +63,16 @@ func (c *InMemoryCache) Put(pluginName, oldRevision, newRevision string, patch [
 	return nil
 }
 
+// writes in place the result to the patchf io.Writer
+func GenerateIOStreamPatch(oldBin io.Reader, newBin io.Reader, patchf io.Writer) error {
+	return bsdiff.Reader(oldBin, newBin, patchf)
+}
+
+// writes in place the result to the newBin io.Writer
+func ApplyIOStreamPatch(oldBin io.Reader, patchf io.Reader, newBin io.Writer) error {
+	return bspatch.Reader(oldBin, newBin, patchf)
+}
+
 func GeneratePatch(outdatedBytes, newestBytes []byte) ([]byte, error) {
 	// BSDIFF4 patch
 	patch, err := bsdiff.Bytes(outdatedBytes, newestBytes)

--- a/pkg/patch/server.go
+++ b/pkg/patch/server.go
@@ -288,10 +288,16 @@ func PatchWith(
 			case v1.PatchOp_UPDATE:
 				if info.GetIsPatch() { // patch received from gateway
 					lg.Info("patching plugin")
+					// existingPluginFile, err := os.Open(fullPluginPath)
+					// if err != nil {
+					// 	return err
+					// }
+					// bufReader := bufio.NewReader(existingPluginFile)
 					existingData, err := os.ReadFile(fullPluginPath)
 					if err != nil {
 						return err
 					}
+					// TODO : use a streaming patcher
 					patchResult, err := ApplyPatch(existingData, receivedData)
 					if err != nil {
 						return err
@@ -319,6 +325,7 @@ func PatchWith(
 						go func() {
 							defer backgroundTasks.Done()
 							lg.Info("computing patch")
+							// TODO : use a streaming patcher
 							patch, err := GeneratePatch(existingData, receivedData)
 							if err != nil {
 								lg.With(


### PR DESCRIPTION
Old performance estimate (4 plugins = 25MB *2):
![old perf estimate](https://user-images.githubusercontent.com/56211853/198110758-9f858084-761b-4626-9b26-0170330d15f1.png)

New performance estimate (5 plugins = 30MB *2):
- re-arranging some file operations
- stream buffered io
![new perf estimate](https://user-images.githubusercontent.com/56211853/198110837-17d87a65-65a3-4cc0-8a87-e47bdebabef5.png)
