### PR TITLE
Update nats error checking logic to use new exported error type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/mattn/go-tty v0.0.4
 	github.com/mikefarah/yq/v4 v4.30.4
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/nats-io/nats.go v1.20.0
+	github.com/nats-io/nats.go v1.21.0
 	github.com/nats-io/nkeys v0.3.0
 	github.com/olebedev/when v0.0.0-20211212231525-59bd4edcf9d6
 	github.com/onsi/ginkgo/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -2205,8 +2205,8 @@ github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a/go.mod h1:0tqz9Hl
 github.com/nats-io/nats-server/v2 v2.8.4 h1:0jQzze1T9mECg8YZEl8+WYUXb9JKluJfCBriPUtluB4=
 github.com/nats-io/nats-server/v2 v2.8.4/go.mod h1:8zZa+Al3WsESfmgSs98Fi06dRWLH5Bnq90m5bKD/eT4=
 github.com/nats-io/nats.go v1.15.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
-github.com/nats-io/nats.go v1.20.0 h1:T8JJnQfVSdh1CzGiwAOv5hEobYCBho/0EupGznYw0oM=
-github.com/nats-io/nats.go v1.20.0/go.mod h1:tLqubohF7t4z3du1QDPYJIQQyhb4wl6DhjxEajSI7UA=
+github.com/nats-io/nats.go v1.21.0 h1:kQiWyQMMMIPjDR7NanrLhTnRUxWgU04yrzmYdq9JxCU=
+github.com/nats-io/nats.go v1.21.0/go.mod h1:tLqubohF7t4z3du1QDPYJIQQyhb4wl6DhjxEajSI7UA=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/pkg/storage/jetstream/cluster_store.go
+++ b/pkg/storage/jetstream/cluster_store.go
@@ -23,7 +23,7 @@ func (s *JetStreamStore) CreateCluster(ctx context.Context, cluster *corev1.Clus
 	}
 	rev, err := s.kv.Clusters.Create(cluster.Id, data)
 	if err != nil {
-		if errIsKeyAlreadyExists(err) {
+		if errors.Is(err, nats.ErrKeyExists) {
 			return storage.ErrAlreadyExists
 		}
 		return fmt.Errorf("failed to create cluster: %w", err)

--- a/pkg/storage/jetstream/jetstream.go
+++ b/pkg/storage/jetstream/jetstream.go
@@ -2,7 +2,6 @@ package jetstream
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -169,14 +168,4 @@ func (s *JetStreamStore) KeyValueStore(prefix string) storage.KeyValueStore {
 	return &jetstreamKeyValueStore{
 		kv: bucket,
 	}
-}
-
-func errIsKeyAlreadyExists(err error) bool {
-	// TODO: this error code is not exported by the nats.go client
-	// https://github.com/nats-io/nats.go/issues/1134
-	apierror := &nats.APIError{}
-	if errors.As(err, &apierror) {
-		return apierror.ErrorCode == 10071
-	}
-	return false
 }

--- a/pkg/storage/jetstream/rbac_store.go
+++ b/pkg/storage/jetstream/rbac_store.go
@@ -16,7 +16,7 @@ func (s *JetStreamStore) CreateRole(ctx context.Context, role *corev1.Role) erro
 		return err
 	}
 	_, err = s.kv.Roles.Create(role.Id, data)
-	if errIsKeyAlreadyExists(err) {
+	if errors.Is(err, nats.ErrKeyExists) {
 		return storage.ErrAlreadyExists
 	}
 	return err
@@ -53,7 +53,7 @@ func (s *JetStreamStore) CreateRoleBinding(ctx context.Context, rb *corev1.RoleB
 		return err
 	}
 	_, err = s.kv.RoleBindings.Create(rb.Id, data)
-	if errIsKeyAlreadyExists(err) {
+	if errors.Is(err, nats.ErrKeyExists) {
 		return storage.ErrAlreadyExists
 	}
 	return err


### PR DESCRIPTION
A fix for https://github.com/nats-io/nats.go/issues/1134 was recently merged, so we can remove our workaround.