### PR TITLE
Fix up cpu inferencing service to also use 0.7 threshold for inferencing

### DIFF
--- a/controllers/ai_opnicluster_controller_test.go
+++ b/controllers/ai_opnicluster_controller_test.go
@@ -167,7 +167,7 @@ var _ = Describe("AI OpniCluster Controller", Ordered, Label("controller"), func
 
 		By("checking hyperparameters config")
 		defaultHyperParameters, _ := json.MarshalIndent(map[string]intstr.IntOrString{
-			"modelThreshold": intstr.FromString("0.5"),
+			"modelThreshold": intstr.FromString("0.7"),
 			"minLogTokens":   intstr.FromInt(5),
 		}, "", "  ")
 		Eventually(Object(&corev1.ConfigMap{

--- a/pkg/resources/opnicluster/services.go
+++ b/pkg/resources/opnicluster/services.go
@@ -702,7 +702,7 @@ func (r *Reconciler) nulogHyperparameters() (runtime.Object, reconciler.DesiredS
 		data = r.spec.NulogHyperparameters
 	} else {
 		data = map[string]intstr.IntOrString{
-			"modelThreshold": intstr.FromString("0.5"),
+			"modelThreshold": intstr.FromString("0.7"),
 			"minLogTokens":   intstr.FromInt(5),
 		}
 	}


### PR DESCRIPTION
This PR sets the CPU inferencing service to use 0.7 as the threshold to be consistent with the GPU inferencing service.