### PR TITLE
Set min log tokens to 1 for cpu inferencing service

### DIFF
--- a/controllers/ai_opnicluster_controller_test.go
+++ b/controllers/ai_opnicluster_controller_test.go
@@ -168,7 +168,7 @@ var _ = Describe("AI OpniCluster Controller", Ordered, Label("controller"), func
 		By("checking hyperparameters config")
 		defaultHyperParameters, _ := json.MarshalIndent(map[string]intstr.IntOrString{
 			"modelThreshold": intstr.FromString("0.7"),
-			"minLogTokens":   intstr.FromInt(5),
+			"minLogTokens":   intstr.FromInt(1),
 		}, "", "  ")
 		Eventually(Object(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/opnicluster/services.go
+++ b/pkg/resources/opnicluster/services.go
@@ -703,7 +703,7 @@ func (r *Reconciler) nulogHyperparameters() (runtime.Object, reconciler.DesiredS
 	} else {
 		data = map[string]intstr.IntOrString{
 			"modelThreshold": intstr.FromString("0.7"),
-			"minLogTokens":   intstr.FromInt(5),
+			"minLogTokens":   intstr.FromInt(1),
 		}
 	}
 	cm, err := hyperparameters.GenerateHyperparametersConfigMap("nulog", r.instanceNamespace, data)


### PR DESCRIPTION
This PR sets the min log token to 1 from 5 to make it consistent with the GPU inferencing service.