### PR TITLE
Have training plugin reset statistics for next model

### DIFF
--- a/plugins/aiops/pkg/gateway/modeltraining.go
+++ b/plugins/aiops/pkg/gateway/modeltraining.go
@@ -34,7 +34,7 @@ func (p *AIOpsPlugin) TrainModel(ctx context.Context, in *modeltraining.ModelTra
 	}
 	msg, err := p.natsConnection.Get().Request("train_model", jsonParameters, time.Minute)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Failed to train model: %v", err)
+		return nil, status.Errorf(codes.Unavailable, "Failed to train model: %v", err)
 	}
 	_, err = p.PutModelTrainingStatus(ctx, &modeltraining.ModelTrainingStatistics{RemainingTime: 3600})
 	if err != nil {

--- a/plugins/aiops/pkg/gateway/modeltraining.go
+++ b/plugins/aiops/pkg/gateway/modeltraining.go
@@ -36,6 +36,10 @@ func (p *AIOpsPlugin) TrainModel(ctx context.Context, in *modeltraining.ModelTra
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to train model: %v", err)
 	}
+	_, err = p.PutModelTrainingStatus(ctx, &modeltraining.ModelTrainingStatistics{RemainingTime: 3600})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to put model training status: %v", err)
+	}
 	return &modeltraining.ModelTrainingResponse{
 		Response: string(msg.Data),
 	}, nil


### PR DESCRIPTION
This PR resets the training statistics for a model when a new training job is submitted.