### PR TITLE
Update services.go for enabling workload DRAIN service with GPU services

### DIFF
--- a/pkg/resources/opnicluster/services.go
+++ b/pkg/resources/opnicluster/services.go
@@ -266,7 +266,11 @@ func (r *Reconciler) workloadDrainDeployment() (resources.Resource, error) {
 			},
 		}
 		ctrl.SetControllerReference(r.opniCluster, deployment, r.client.Scheme())
-		return deployment, deploymentStateDisabled(r.opniCluster.Spec.Services.Drain.Enabled), nil
+		var state = reconciler.StateAbsent
+		if lo.FromPtrOr(r.opniCluster.Spec.Services.Drain.Workload.Enabled, false) && lo.FromPtrOr(r.opniCluster.Spec.Services.Drain.Enabled, true) {
+			state = reconciler.StatePresent
+		}
+		return deployment, state, nil
 	}, nil
 }
 


### PR DESCRIPTION
This PR addresses a bug in the RC where workload drain services were not being enabled correctly.