### PR TITLE
fix alerting install conflict by unsetting fields in uninstall

### DIFF
--- a/plugins/alerting/pkg/alerting/drivers/alerting_driver_helpers.go
+++ b/plugins/alerting/pkg/alerting/drivers/alerting_driver_helpers.go
@@ -55,7 +55,8 @@ func (a *AlertingManager) alertingControllerStatus(gw *corev1beta1.Gateway) (*al
 			}
 		}
 		controller := ss.(*appsv1.StatefulSet)
-		if controller.Status.Replicas != controller.Status.AvailableReplicas {
+		if controller.Status.Replicas != controller.Status.AvailableReplicas ||
+			controller.Status.AvailableReplicas != gw.Spec.Alerting.Replicas {
 			return &alertops.InstallStatus{
 				State: alertops.InstallState_InstallUpdating,
 			}, nil


### PR DESCRIPTION
when uninstalling the alerting cluster, unset configurable fields.

When the configurable fields are unset, it uses the defaults on the subsequent install. The UI handles applying configuration from users.