### PR TITLE
Add state tracking to admin creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/mattn/go-tty v0.0.4
 	github.com/mikefarah/yq/v4 v4.30.4
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/nats-io/nats-server/v2 v2.8.4
 	github.com/nats-io/nats.go v1.21.0
 	github.com/nats-io/nkeys v0.3.0
 	github.com/olebedev/when v0.0.0-20211212231525-59bd4edcf9d6
@@ -352,6 +353,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mholt/archiver/v4 v4.0.0-alpha.3 // indirect
 	github.com/miekg/dns v1.1.50 // indirect
+	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/minio/md5-simd v1.1.0 // indirect
 	github.com/minio/minio-go/v7 v7.0.10 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
@@ -379,6 +381,7 @@ require (
 	github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncw/swift v1.0.52 // indirect
 	github.com/nwaples/rardecode/v2 v2.0.0-beta.2 // indirect

--- a/plugins/logging/pkg/gateway/admin_v2_test.go
+++ b/plugins/logging/pkg/gateway/admin_v2_test.go
@@ -117,6 +117,7 @@ var _ = Describe("Opensearch Admin V2", Ordered, Label("unit"), func() {
 			WithRestConfig(restConfig),
 			WithVersion(version),
 			WithOpensearchCluster(opniCluster),
+			WithNatsConnection(nc),
 		)
 		manager = plugin.NewLoggingManagerForPlugin()
 	})

--- a/plugins/logging/pkg/gateway/drivers/kubernetes_manager.go
+++ b/plugins/logging/pkg/gateway/drivers/kubernetes_manager.go
@@ -168,7 +168,7 @@ func (d *KubernetesManagerDriver) GetCredentials(ctx context.Context, id string)
 	}
 
 	if len(secrets.Items) != 1 {
-		d.logger.Error("no credential secrets found")
+		d.logger.Warn("no credential secrets found")
 		return
 	}
 

--- a/plugins/logging/pkg/gateway/opensearch.go
+++ b/plugins/logging/pkg/gateway/opensearch.go
@@ -15,8 +15,10 @@ import (
 func (p *Plugin) GetDetails(ctx context.Context, cluster *opensearch.ClusterReference) (*opensearch.OpensearchDetails, error) {
 
 	// Get the external URL
-	var binding *loggingv1beta1.MulticlusterRoleBinding
-	var opnimgmt *loggingv1beta1.OpniOpensearch
+	var (
+		binding  *loggingv1beta1.MulticlusterRoleBinding
+		opnimgmt *loggingv1beta1.OpniOpensearch
+	)
 
 	opnimgmt = &loggingv1beta1.OpniOpensearch{}
 	if err := p.k8sClient.Get(ctx, types.NamespacedName{

--- a/plugins/logging/pkg/gateway/suite_test.go
+++ b/plugins/logging/pkg/gateway/suite_test.go
@@ -3,6 +3,7 @@ package gateway_test
 import (
 	"testing"
 
+	"github.com/nats-io/nats.go"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher/opni/pkg/test"
@@ -17,6 +18,7 @@ var (
 	restConfig *rest.Config
 	scheme     *runtime.Scheme
 	k8sManager ctrl.Manager
+	nc         *nats.Conn
 )
 
 func TestAPIs(t *testing.T) {
@@ -38,6 +40,9 @@ var _ = BeforeSuite(func() {
 	restConfig, scheme, err = env.StartK8s()
 	Expect(err).NotTo(HaveOccurred())
 
+	nc, err = env.StartEmbeddedJetstream()
+	Expect(err).NotTo(HaveOccurred())
+
 	k8sClient, err = client.New(restConfig, client.Options{
 		Scheme: scheme,
 	})
@@ -49,6 +54,7 @@ var _ = BeforeSuite(func() {
 
 	DeferCleanup(func() {
 		By("tearing down the test environment")
+		nc.Close()
 		err := env.Stop()
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/plugins/logging/pkg/opensearchdata/admin.go
+++ b/plugins/logging/pkg/opensearchdata/admin.go
@@ -134,6 +134,7 @@ func (m *Manager) ShouldCreateInitialAdmin() bool {
 	}
 
 	if !idExists {
+		m.logger.Debug("no opensearch cluster created, not creating admin user")
 		return false
 	}
 
@@ -145,11 +146,13 @@ func (m *Manager) ShouldCreateInitialAdmin() bool {
 
 	switch string(adminState.Value()) {
 	case initialAdminPending:
+		m.logger.Debug("admin user creation is pending, restarting")
 		return true
 	case initialAdminCreated:
+		m.logger.Debug("admin user already created, not restarting")
 		return false
 	default:
-		m.logger.Errorf("invalid initial admin state returned")
+		m.logger.Error("invalid initial admin state returned")
 		return false
 	}
 }

--- a/plugins/logging/pkg/opensearchdata/admin.go
+++ b/plugins/logging/pkg/opensearchdata/admin.go
@@ -10,8 +10,23 @@ import (
 	opensearchtypes "github.com/rancher/opni/pkg/opensearch/opensearch/types"
 )
 
+const (
+	initialAdminKey     = "initial-admin"
+	initialAdminPending = "pending"
+	initialAdminCreated = "created"
+)
+
 func (m *Manager) CreateInitialAdmin(password []byte, readyFunc ...ReadyFunc) {
 	m.WaitForInit()
+	m.kv.SetClient(m.setJetStream)
+	m.kv.WaitForInit()
+
+	m.adminInitStateRW.Lock()
+	_, err := m.kv.PutString(initialAdminKey, initialAdminPending)
+	if err != nil {
+		m.logger.Warnf("failed to store initial admin state: %v", err)
+	}
+	m.adminInitStateRW.Unlock()
 
 	for _, r := range readyFunc {
 		exitEarly := r()
@@ -57,6 +72,13 @@ CREATE:
 			break CREATE
 		}
 	}
+
+	m.adminInitStateRW.Lock()
+	_, err = m.kv.PutString(initialAdminKey, initialAdminCreated)
+	if err != nil {
+		m.logger.Warnf("failed to store initial admin state: %v", err)
+	}
+	m.adminInitStateRW.Unlock()
 }
 
 func (m *Manager) userExists(ctx context.Context, name string) (bool, error) {
@@ -96,4 +118,47 @@ func (m *Manager) maybeCreateUser(ctx context.Context, user opensearchtypes.User
 	}
 	m.logger.Debugf("user successfully created: %s", resp.String())
 	return nil
+}
+
+func (m *Manager) ShouldCreateInitialAdmin() bool {
+	m.kv.SetClient(m.setJetStream)
+	m.kv.WaitForInit()
+
+	m.adminInitStateRW.RLock()
+	defer m.adminInitStateRW.RUnlock()
+
+	idExists, err := m.keyExists(initialAdminKey)
+	if err != nil {
+		m.logger.Errorf("failed to check initial admin state: %v", err)
+		return false
+	}
+
+	if !idExists {
+		return false
+	}
+
+	adminState, err := m.kv.Get(initialAdminKey)
+	if err != nil {
+		m.logger.Errorf("failed to check initial admin state: %v", err)
+		return false
+	}
+
+	switch string(adminState.Value()) {
+	case initialAdminPending:
+		return true
+	case initialAdminCreated:
+		return false
+	default:
+		m.logger.Errorf("invalid initial admin state returned")
+		return false
+	}
+}
+
+func (m *Manager) DeleteInitialAdminState() error {
+	m.kv.SetClient(m.setJetStream)
+	m.kv.WaitForInit()
+	m.adminInitStateRW.Lock()
+	defer m.adminInitStateRW.Unlock()
+
+	return m.kv.Delete(initialAdminKey)
 }


### PR DESCRIPTION
This will ensure that if the gateway is restarted before the opensearch admin user is successfully created the creation of the admin user will be picked up again.

Fixes #930 