### PR TITLE
fix minimal build issue

### DIFF
--- a/pkg/opni/commands/completion.go
+++ b/pkg/opni/commands/completion.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"github.com/rancher/opni/plugins/metrics/pkg/apis/remoteread"
 	"os"
 	"strings"
 	"time"
@@ -210,37 +209,4 @@ func completeBootstrapTokens(cmd *cobra.Command, args []string, toComplete strin
 		}
 	}
 	return comps, cobra.ShellCompDirectiveNoFileComp
-}
-
-func completeImportTargets(cmd *cobra.Command, args []string, toComplete string, _ ...func(token *corev1.BootstrapToken) bool) ([]string, cobra.ShellCompDirective) {
-	if err := importPreRunE(cmd, nil); err != nil {
-		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
-	}
-
-	var cluster string
-	if len(args) >= 1 {
-		cluster = args[1]
-	}
-
-	targetList, err := remoteReadClient.ListTargets(cmd.Context(), &remoteread.TargetListRequest{
-		ClusterId: cluster,
-	})
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-
-	var targets []string
-	for _, target := range targetList.Targets {
-		name := target.Meta.Name
-
-		if slices.Contains(args, name) {
-			continue
-		}
-
-		if strings.HasPrefix(name, toComplete) {
-			targets = append(targets, name)
-		}
-	}
-
-	return targets, cobra.ShellCompDirectiveNoFileComp
 }

--- a/pkg/opni/commands/completion_plugins.go
+++ b/pkg/opni/commands/completion_plugins.go
@@ -1,0 +1,44 @@
+//go:build !noplugins
+
+package commands
+
+import (
+	corev1 "github.com/rancher/opni/pkg/apis/core/v1"
+	"github.com/rancher/opni/plugins/metrics/pkg/apis/remoteread"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+	"strings"
+)
+
+func completeImportTargets(cmd *cobra.Command, args []string, toComplete string, _ ...func(token *corev1.BootstrapToken) bool) ([]string, cobra.ShellCompDirective) {
+	if err := importPreRunE(cmd, nil); err != nil {
+		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var cluster string
+	if len(args) >= 1 {
+		cluster = args[1]
+	}
+
+	targetList, err := remoteReadClient.ListTargets(cmd.Context(), &remoteread.TargetListRequest{
+		ClusterId: cluster,
+	})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var targets []string
+	for _, target := range targetList.Targets {
+		name := target.Meta.Name
+
+		if slices.Contains(args, name) {
+			continue
+		}
+
+		if strings.HasPrefix(name, toComplete) {
+			targets = append(targets, name)
+		}
+	}
+
+	return targets, cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/opni/commands/import_progress.go
+++ b/pkg/opni/commands/import_progress.go
@@ -1,3 +1,5 @@
+//go:build !noplugins
+
 package commands
 
 import (


### PR DESCRIPTION
There were some missing `//go:build !noplugins` build constraints in files related to the recent [ETL tool PR](https://github.com/rancher/opni/pull/1014)