### PR TITLE
Update questions.yaml to match defaults

### DIFF
--- a/packages/opni-agent/opni-agent/charts/questions.yaml
+++ b/packages/opni-agent/opni-agent/charts/questions.yaml
@@ -14,5 +14,5 @@ questions:
   valid_chars: 'http(s)?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
 - variable: kube-prometheus-stack.enabled
   label: Install Prometheus Operator
-  default: "false"
+  default: "true"
   type: boolean


### PR DESCRIPTION
https://github.com/rancher/opni/blob/d1d8ae4abbb12f85220d3d480dddfa49fe0abf11/packages/opni-agent/opni-agent/charts/values.yaml#L102 is set to true by default. Without this checked by default, there is a default mismatch when installing through the Rancher UI