### PR TITLE
fix issue with nil namespace in discovery request

### DIFF
--- a/pkg/opni/commands/import.go
+++ b/pkg/opni/commands/import.go
@@ -435,10 +435,7 @@ func BuildDiscoverCmd() *cobra.Command {
 
 			request := &remoteread.DiscoveryRequest{
 				ClusterIds: clusterIds,
-			}
-
-			if namespace != "" {
-				request.Namespace = &namespace
+				Namespace:  &namespace,
 			}
 
 			response, err := remoteReadClient.Discover(cmd.Context(), request)

--- a/plugins/metrics/pkg/agent/node.go
+++ b/plugins/metrics/pkg/agent/node.go
@@ -224,7 +224,12 @@ func (m *MetricsNode) Discover(ctx context.Context, request *remoteread.Discover
 		}, nil
 	}
 
-	entries, err := m.nodeDriver.DiscoverPrometheuses(ctx, *request.Namespace)
+	var namespace string
+	if request.Namespace != nil {
+		namespace = *request.Namespace
+	}
+
+	entries, err := m.nodeDriver.DiscoverPrometheuses(ctx, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("could not discover Prometheus instances: %w", err)
 	}

--- a/plugins/metrics/pkg/agent/node.go
+++ b/plugins/metrics/pkg/agent/node.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/opni/pkg/clients"
 	"github.com/rancher/opni/plugins/metrics/pkg/apis/remoteread"
 	"github.com/rancher/opni/plugins/metrics/pkg/apis/remotewrite"
+	"github.com/samber/lo"
 	"net/http"
 	"sort"
 	"strings"
@@ -224,10 +225,7 @@ func (m *MetricsNode) Discover(ctx context.Context, request *remoteread.Discover
 		}, nil
 	}
 
-	var namespace string
-	if request.Namespace != nil {
-		namespace = *request.Namespace
-	}
+	namespace := lo.FromPtrOr[string](request.Namespace, "")
 
 	entries, err := m.nodeDriver.DiscoverPrometheuses(ctx, namespace)
 	if err != nil {


### PR DESCRIPTION
Running `opni import discover` without a namespace filter causes `nil pointer dereference`. This PR resolves that oversight.