### PR TITLE
check all installed capabilites in alarm status

### DIFF
--- a/plugins/alerting/pkg/alerting/api_conditions.go
+++ b/plugins/alerting/pkg/alerting/api_conditions.go
@@ -211,12 +211,12 @@ func (p *Plugin) checkMetricsClusterStatus(
 			Reason: "cluster not found",
 		}
 	}
-	for _, cap := range cluster.Metadata.Capabilities {
-		if cap.Name != wellknown.CapabilityMetrics {
-			return &alertingv1.AlertStatusResponse{
-				State:  alertingv1.AlertConditionState_Invalidated,
-				Reason: "cluster does not have metrics capabilities installed",
-			}
+	if len(lo.Filter(cluster.Metadata.Capabilities, func(cap *corev1.ClusterCapability, _ int) bool {
+		return cap.Name == wellknown.CapabilityMetrics
+	})) == 0 {
+		return &alertingv1.AlertStatusResponse{
+			State:  alertingv1.AlertConditionState_Invalidated,
+			Reason: "cluster does not have metrics capabilities installed",
 		}
 	}
 	if !cond.GetLastUpdated().AsTime().Before(time.Now().Add(-time.Second * 90)) {


### PR DESCRIPTION
Check the full list of capabilities when determining if metrics is installed for evaluating metric alarm status health.