### PR TITLE
Update opensearch query for getting log counts by deployment

### DIFF
--- a/plugins/aiops/pkg/gateway/aggregation.go
+++ b/plugins/aiops/pkg/gateway/aggregation.go
@@ -84,7 +84,7 @@ func (p *AIOpsPlugin) aggregateWorkloadLogs() {
 					},
 					{
 						"regexp": map[string]any{
-							"kubernetes.namespace_name.keyword": ".+",
+							"namespace_name.keyword": ".+",
 						},
 					},
 					{
@@ -110,7 +110,7 @@ func (p *AIOpsPlugin) aggregateWorkloadLogs() {
 						{
 							"namespace_name": map[string]any{
 								"terms": map[string]any{
-									"field": "kubernetes.namespace_name.keyword",
+									"field": "namespace_name.keyword",
 								},
 							},
 						},


### PR DESCRIPTION
This PR updates the Opensearch query by aggregating on the field "namespace_name" instead of "kubernetes.namespace_name"

Addresses https://github.com/rancher/opni/issues/1180