### PR TITLE
Update AIOps gateway plugin to use Nats Jetstream KV storage for storing model training parameters

### DIFF
--- a/aiops/requirements.txt
+++ b/aiops/requirements.txt
@@ -1,5 +1,5 @@
 elasticsearch[async]==7.13.0
 numpy==1.22.0
-opni-nats==0.0.0.4
+opni-nats==0.1.0
 opni-proto==0.6.1.0
 pandas==1.2.3

--- a/images/python/requirements.txt
+++ b/images/python/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.22.0
-opni-nats==0.0.0.4
+opni-nats==0.1.0
 pandas==1.2.3

--- a/plugins/aiops/pkg/gateway/aggregation.go
+++ b/plugins/aiops/pkg/gateway/aggregation.go
@@ -170,7 +170,7 @@ func (p *AIOpsPlugin) aggregateWorkloadLogs() {
 		return
 	}
 	bytesAggregation := []byte(aggregatedResults)
-	p.kv.Get().Put("aggregation", bytesAggregation)
+	p.aggregationKv.Get().Put("aggregation", bytesAggregation)
 	p.Logger.Info("Updated aggregation of deployments to Jetstream.")
 }
 

--- a/plugins/aiops/pkg/gateway/modeltraining.go
+++ b/plugins/aiops/pkg/gateway/modeltraining.go
@@ -170,12 +170,27 @@ func (p *AIOpsPlugin) GetModelTrainingParameters(ctx context.Context, _ *emptypb
 		}
 		return nil, status.Errorf(codes.NotFound, "Failed to get model training parameters from Jetstream: %v", err)
 	}
+	var parametersArray []*modeltraining.ModelTrainingParameters
+	var resultsStorage = map[string]map[string][]string{}
 	jsonRes := result.Value()
-	var resultsStorage = modeltraining.ModelTrainingParametersList{}
-	if err := protojson.Unmarshal(jsonRes, &resultsStorage); err != nil {
+	if err := json.Unmarshal(jsonRes, &resultsStorage); err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to unmarshal model training parameters from Jetstream: %v", err)
 	}
-	return &resultsStorage, nil
+	for clusterName, namespaces := range resultsStorage {
+		for namespaceName, deployments := range namespaces {
+			for deploymentIdx := range deployments {
+				deploymentData := modeltraining.ModelTrainingParameters{
+					ClusterId:  clusterName,
+					Namespace:  namespaceName,
+					Deployment: deployments[deploymentIdx],
+				}
+				parametersArray = append(parametersArray, &deploymentData)
+			}
+		}
+	}
+	return &modeltraining.ModelTrainingParametersList{
+		Items: parametersArray,
+	}, nil
 }
 
 func (p *AIOpsPlugin) GPUInfo(ctx context.Context, _ *emptypb.Empty) (*modeltraining.GPUInfoList, error) {

--- a/plugins/aiops/pkg/gateway/modeltraining.go
+++ b/plugins/aiops/pkg/gateway/modeltraining.go
@@ -43,6 +43,9 @@ func (p *AIOpsPlugin) TrainModel(ctx context.Context, in *modeltraining.ModelTra
 	}
 	modelTrainingKv.Put("modelTrainingParameters", parametersBytes)
 	natsConnection, err := p.natsConnection.GetContext(ctxca)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to get model training parameters: %v", err)
+	}
 	msg, err := natsConnection.Request("train_model", jsonParameters, time.Minute)
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "Failed to train model: %v", err)
@@ -122,6 +125,9 @@ func (p *AIOpsPlugin) GetModelStatus(ctx context.Context, _ *emptypb.Empty) (*mo
 		return nil, status.Error(codes.Internal, "Failed to get model status.")
 	}
 	statisticsKv, err := p.statisticsKv.GetContext(ctxca)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to get model training status from Jetstream: %v", err)
+	}
 	result, err := statisticsKv.Get("modelTrainingStatus")
 	if err != nil {
 		if errors.Is(err, nats.ErrKeyNotFound) {

--- a/plugins/aiops/pkg/gateway/modeltraining.go
+++ b/plugins/aiops/pkg/gateway/modeltraining.go
@@ -22,6 +22,8 @@ const (
 	modelTrainingParametersKey = "modelTrainingParameters"
 	modelTrainingStatusKey     = "modelTrainingStatus"
 	logAggregationCountKey     = "aggregation"
+	modelTrainingNatsSubject   = "train_model"
+	modelStatusNatsSubject     = "model_status"
 )
 
 func (p *AIOpsPlugin) TrainModel(ctx context.Context, in *modeltraining.ModelTrainingParametersList) (*modeltraining.ModelTrainingResponse, error) {
@@ -52,7 +54,7 @@ func (p *AIOpsPlugin) TrainModel(ctx context.Context, in *modeltraining.ModelTra
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to get model training parameters: %v", err)
 	}
-	msg, err := natsConnection.Request("train_model", jsonParameters, time.Minute)
+	msg, err := natsConnection.Request(modelTrainingNatsSubject, jsonParameters, time.Minute)
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "Failed to train model: %v", err)
 	}
@@ -126,7 +128,7 @@ func (p *AIOpsPlugin) GetModelStatus(ctx context.Context, _ *emptypb.Empty) (*mo
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Failed to get model status.")
 	}
-	msg, err := natsConnection.Request("model_status", b, time.Minute)
+	msg, err := natsConnection.Request(modelStatusNatsSubject, b, time.Minute)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Failed to get model status.")
 	}

--- a/plugins/aiops/pkg/gateway/plugin.go
+++ b/plugins/aiops/pkg/gateway/plugin.go
@@ -143,7 +143,7 @@ func (p *AIOpsPlugin) UseManagementAPI(_ managementv1.ManagementClient) {
 		lg.Fatal(err)
 	}
 
-	p.aggregationKv.Set(modelParametersKeyValue)
+	p.modelTrainingKv.Set(modelParametersKeyValue)
 
 	modelStatisticsKeyValue, err := mgr.CreateKeyValue(&nats.KeyValueConfig{
 		Bucket:      "model-training-statistics",

--- a/plugins/aiops/pkg/gateway/plugin.go
+++ b/plugins/aiops/pkg/gateway/plugin.go
@@ -47,6 +47,12 @@ type PluginOptions struct {
 
 type PluginOption func(*PluginOptions)
 
+const (
+	workloadAggregationCountBucket = "os-workload-aggregation"
+	modelTrainingParametersBucket  = "model-training-parameters"
+	modelTrainingStatisticsBucket  = "model-training-statistics"
+)
+
 func (o *PluginOptions) apply(opts ...PluginOption) {
 	for _, op := range opts {
 		op(o)
@@ -126,7 +132,7 @@ func (p *AIOpsPlugin) UseManagementAPI(_ managementv1.ManagementClient) {
 		lg.Fatal(err)
 	}
 	aggregationKeyValue, err := mgr.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:      "os-workload-aggregation",
+		Bucket:      workloadAggregationCountBucket,
 		Description: "Storing aggregation of workload logs from Opensearch.",
 	})
 	if err != nil {
@@ -136,7 +142,7 @@ func (p *AIOpsPlugin) UseManagementAPI(_ managementv1.ManagementClient) {
 	p.aggregationKv.Set(aggregationKeyValue)
 
 	modelParametersKeyValue, err := mgr.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:      "model-training-parameters",
+		Bucket:      modelTrainingParametersBucket,
 		Description: "Storing the workloads specified for model training.",
 	})
 	if err != nil {
@@ -146,7 +152,7 @@ func (p *AIOpsPlugin) UseManagementAPI(_ managementv1.ManagementClient) {
 	p.modelTrainingKv.Set(modelParametersKeyValue)
 
 	modelStatisticsKeyValue, err := mgr.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:      "model-training-statistics",
+		Bucket:      modelTrainingStatisticsBucket,
 		Description: "Storing the statistics for the training of the model.",
 	})
 	if err != nil {


### PR DESCRIPTION
This PR updates the AIOps gateway plugin to use the Nats kv feature for keeping track of the model training parameters. It also introduces separate KV buckets, os-workload-aggregation, model-training-parameters and model-training-statistics to keep track of different usages of kv storage.

Addresses https://github.com/rancher/opni/issues/1148