### PR TITLE
Switch gateway to recreate deployment

### DIFF
--- a/pkg/resources/gateway/deployment.go
+++ b/pkg/resources/gateway/deployment.go
@@ -45,6 +45,9 @@ func (r *Reconciler) deployment(extraAnnotations map[string]string) ([]resources
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,


### PR DESCRIPTION
When the replacement gateway pod is scheduled to the same node the replacement will fail because the gateway uses a RWO PersistentVolume.  To avoid this the rollout strategy should be recreate.

This means that the gateway won't be highly available, so this will need to be revisited when we work on making it HA.  As part of this work the plugin cache will need to be reworked to avoid using a RWO volume.

Fixes #1209