### PR TITLE
Add prometheus CRD to auto install

### DIFF
--- a/apis/monitoring/v1beta1/prometheus_types.go
+++ b/apis/monitoring/v1beta1/prometheus_types.go
@@ -31,3 +31,16 @@ func PodMonitorCRD() (*crd.CRD, error) {
 		Schema:     schema,
 	}, nil
 }
+
+func PrometheusCRD() (*crd.CRD, error) {
+	schema, err := openapi.ToOpenAPIFromStruct(promoperatorv1.Prometheus{})
+	if err != nil {
+		return nil, err
+	}
+	return &crd.CRD{
+		GVK:        promoperatorv1.SchemeGroupVersion.WithKind("Prometheus"),
+		PluralName: "prometheuses",
+		Status:     true,
+		Schema:     schema,
+	}, nil
+}

--- a/pkg/opni/commands/client.go
+++ b/pkg/opni/commands/client.go
@@ -119,6 +119,8 @@ func BuildClientCmd() *cobra.Command {
 			opnicorev1beta1.KeyringCRD,
 			monitoringv1beta1.ServiceMonitorCRD,
 			monitoringv1beta1.PodMonitorCRD,
+			// Need to include Prometheus CRD for deletes even if we're not using prometheus
+			monitoringv1beta1.PrometheusCRD,
 		} {
 			crd, err := crdFunc()
 			if err != nil {


### PR DESCRIPTION
This will allow users who want to use opentelemetry to not have to install the prometheus operator.