### PR TITLE
Add default evaluation interval field to prometheus spec

### DIFF
--- a/plugins/metrics/pkg/agent/drivers/prometheus_operator/external_operator.go
+++ b/plugins/metrics/pkg/agent/drivers/prometheus_operator/external_operator.go
@@ -194,6 +194,7 @@ func (d *ExternalPromOperatorDriver) buildPrometheus(conf *node.PrometheusSpec) 
 					Key: "prometheus.yaml",
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/rancher/opni/issues/1469

This appears to be the only field causing issues from the missing defaults in the wrangler-generated Prometheus CRD. 