### PR TITLE
Add support label and role creation

### DIFF
--- a/pkg/apis/core/v1/labels.go
+++ b/pkg/apis/core/v1/labels.go
@@ -15,6 +15,7 @@ const (
 	LabelSelectorOpDoesNotExist LabelSelectorOperator = "DoesNotExist"
 
 	NameLabel       = "opni.io/name"
+	SupportLabel    = "opni.io/support-user"
 	LegacyNameLabel = "kubernetes.io/metadata.name"
 )
 

--- a/pkg/crypto/xof.go
+++ b/pkg/crypto/xof.go
@@ -1,0 +1,37 @@
+package crypto
+
+import (
+	"errors"
+
+	"golang.org/x/crypto/sha3"
+)
+
+type PRFXOFHasher interface {
+	Hash(data []byte, outputLen int) ([]byte, error)
+}
+
+type cshakeHasher struct {
+	domain []byte
+	key    []byte
+}
+
+func NewCShakeHasher(secretKey []byte, domain string) PRFXOFHasher {
+	return &cshakeHasher{
+		domain: []byte(domain),
+		key:    secretKey,
+	}
+}
+
+func (c *cshakeHasher) Hash(data []byte, outputLen int) ([]byte, error) {
+	if outputLen < 32 {
+		return nil, errors.New("invalid output length, must be at least 32 bytes")
+	}
+	d := sha3.NewCShake256(nil, c.domain)
+
+	d.Write(c.key)
+	d.Write(data)
+
+	h := make([]byte, outputLen)
+	d.Read(h)
+	return h, nil
+}

--- a/pkg/opni/commands/manager.go
+++ b/pkg/opni/commands/manager.go
@@ -96,6 +96,11 @@ func BuildManagerCmd() *cobra.Command {
 			return err
 		}
 
+		if err = (&controllers.LoggingMulticlusterUserReconciler{}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Logging MulticlusterUser")
+			return err
+		}
+
 		if err = (&controllers.LoggingMulticlusterRoleBindingReconciler{}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Logging MulticlusterRoleBinding")
 			return err

--- a/pkg/opni/commands/tokens.go
+++ b/pkg/opni/commands/tokens.go
@@ -76,7 +76,8 @@ func BuildTokensCreateSupportCmd() *cobra.Command {
 			}
 
 			labels := map[string]string{
-				corev1.NameLabel: username,
+				corev1.NameLabel:    username,
+				corev1.SupportLabel: "true",
 			}
 			t, err := mgmtClient.CreateBootstrapToken(cmd.Context(),
 				&managementv1.CreateBootstrapTokenRequest{

--- a/pkg/supportagent/config/supportagent.go
+++ b/pkg/supportagent/config/supportagent.go
@@ -120,12 +120,7 @@ func GatewayClientFromConfig(
 		return nil, ErrNoConfig
 	}
 
-	krData, err := openKeyRingData(pwdFunc)
-	if err != nil {
-		return nil, err
-	}
-
-	kr, err := keyring.Unmarshal(krData)
+	kr, err := LoadKeyring(pwdFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -149,6 +144,15 @@ func GatewayClientFromConfig(
 
 	controlv1.RegisterIdentityServer(client, identserver.NewFromProvider(ip))
 	return client, nil
+}
+
+func LoadKeyring(pwdFunc keystore.PromptFunc) (keyring.Keyring, error) {
+	krData, err := openKeyRingData(pwdFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyring.Unmarshal(krData)
 }
 
 func ensureDirExists(path string) error {

--- a/pkg/supportagent/metadata.go
+++ b/pkg/supportagent/metadata.go
@@ -2,4 +2,6 @@ package supportagent
 
 const (
 	AttributeValuesKey = "attribute-values"
+
+	SupportAgentDomain = "support-agent"
 )

--- a/plugins/logging/pkg/backend/install.go
+++ b/plugins/logging/pkg/backend/install.go
@@ -9,10 +9,11 @@ import (
 	opnicorev1 "github.com/rancher/opni/pkg/apis/core/v1"
 	"github.com/rancher/opni/pkg/capabilities"
 	"github.com/rancher/opni/pkg/capabilities/wellknown"
+	"github.com/rancher/opni/pkg/crypto"
 	"github.com/rancher/opni/pkg/keyring"
 	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/supportagent"
 	driver "github.com/rancher/opni/plugins/logging/pkg/gateway/drivers/backend"
-	"golang.org/x/crypto/blake2b"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -129,10 +130,7 @@ func (b *LoggingBackend) generatePassword(ctx context.Context, cluster *opnicore
 		return []byte{}, errors.New("keyring does not contain shared keys")
 	}
 
-	hash, err := blake2b.New512(sharedKeys.ClientKey)
-	if err != nil {
-		return []byte{}, err
-	}
+	hasher := crypto.NewCShakeHasher(sharedKeys.ServerKey, supportagent.SupportAgentDomain)
 
-	return hash.Sum(nil), nil
+	return hasher.Hash(sharedKeys.ClientKey, 32)
 }

--- a/plugins/logging/pkg/backend/install.go
+++ b/plugins/logging/pkg/backend/install.go
@@ -2,13 +2,17 @@ package backend
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 
 	capabilityv1 "github.com/rancher/opni/pkg/apis/capability/v1"
 	opnicorev1 "github.com/rancher/opni/pkg/apis/core/v1"
 	"github.com/rancher/opni/pkg/capabilities"
 	"github.com/rancher/opni/pkg/capabilities/wellknown"
+	"github.com/rancher/opni/pkg/keyring"
 	"github.com/rancher/opni/pkg/storage"
 	driver "github.com/rancher/opni/plugins/logging/pkg/gateway/drivers/backend"
+	"golang.org/x/crypto/blake2b"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -66,6 +70,19 @@ func (b *LoggingBackend) Install(ctx context.Context, req *capabilityv1.InstallR
 		warningErr = err
 	}
 
+	supportLabelValue, ok := cluster.GetMetadata().GetLabels()[opnicorev1.SupportLabel]
+	supportUser := ok && supportLabelValue == "true"
+	if supportUser {
+		p, err := b.generatePassword(ctx, req.GetCluster())
+		if err != nil {
+			return nil, err
+		}
+		err = b.ClusterDriver.StoreClusterReadUser(ctx, name, base64.StdEncoding.EncodeToString(p), cluster.GetId())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	_, err = b.StorageBackend.UpdateCluster(ctx, req.Cluster,
 		storage.NewAddCapabilityMutator[*opnicorev1.Cluster](capabilities.Cluster(wellknown.CapabilityLogs)),
 	)
@@ -96,4 +113,26 @@ func (b *LoggingBackend) InstallerTemplate(context.Context, *emptypb.Empty) (*ca
 			`{{ arg "toggle" "Install Prometheus Operator" "+omitEmpty" "+default:false" "+format:--set kube-prometheus-stack.enabled={{ value }}" }} ` +
 			`--create-namespace`,
 	}, nil
+}
+
+func (b *LoggingBackend) generatePassword(ctx context.Context, cluster *opnicorev1.Reference) ([]byte, error) {
+	krStore := b.StorageBackend.KeyringStore("gateway", cluster)
+	kr, err := krStore.Get(ctx)
+	if err != nil {
+		return []byte{}, err
+	}
+	var sharedKeys *keyring.SharedKeys
+	ok := kr.Try(func(key *keyring.SharedKeys) {
+		sharedKeys = key
+	})
+	if !ok {
+		return []byte{}, errors.New("keyring does not contain shared keys")
+	}
+
+	hash, err := blake2b.New512(sharedKeys.ClientKey)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return hash.Sum(nil), nil
 }

--- a/plugins/logging/pkg/errors/errors.go
+++ b/plugins/logging/pkg/errors/errors.go
@@ -8,6 +8,7 @@ import (
 var (
 	ErrClusterAlreadyExists    = errors.New("cluster already exists")
 	ErrInvalidList             = errors.New("list did not return exactly 1 result")
+	ErrLoggingClusterNotFound  = errors.New("logging cluster not found")
 	ErrInvalidPersistence      = errors.New("invalid persistence config")
 	ErrInvalidCluster          = errors.New("invalid opensearch cluster")
 	ErrClusterIDMissing        = errors.New("request does not include cluster ID")

--- a/plugins/logging/pkg/gateway/drivers/backend/cluster_driver.go
+++ b/plugins/logging/pkg/gateway/drivers/backend/cluster_driver.go
@@ -21,9 +21,11 @@ type ClusterDriver interface {
 	GetInstallStatus(context.Context) InstallState
 	StoreCluster(context.Context, *corev1.Reference, string) error
 	StoreClusterMetadata(context.Context, string, string) error
+	StoreClusterReadUser(ctx context.Context, username, password, id string) error
 	DeleteCluster(context.Context, string) error
 	SetClusterStatus(context.Context, string, bool) error
 	GetClusterStatus(context.Context, string) (*capabilityv1.NodeCapabilityStatus, error)
+
 	SetSyncTime()
 }
 

--- a/plugins/logging/test/test_drivers.go
+++ b/plugins/logging/test/test_drivers.go
@@ -180,6 +180,10 @@ func (d *MockBackendDriver) GetClusterStatus(_ context.Context, id string) (*cap
 	}, nil
 }
 
+func (d *MockBackendDriver) StoreClusterReadUser(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (d *MockBackendDriver) SetSyncTime() {
 	d.syncM.Lock()
 	defer d.syncM.Unlock()


### PR DESCRIPTION
This PR does the following things:

- Adds a well known Opni label to designate a cluster is actually a support user
- Creates a user account for Opensearch when the logging capability is added to a support user
- Generates the password for that account ratcheted off the client key
- Adds a command to the support CLI to display the generated password.

Fixes #1568 