### PR TITLE
Update role and rb tests for validations

### DIFF
--- a/test/integration/managementapi_rolebindings_test.go
+++ b/test/integration/managementapi_rolebindings_test.go
@@ -231,8 +231,9 @@ var _ = Describe("Management API Rolebinding Management Tests", Ordered, Label("
 
 	It("cannot update a non existent role binding", func() {
 		_, err = client.UpdateRoleBinding(context.Background(), &corev1.RoleBinding{
-			Id:     "does-not-exist",
-			RoleId: "test-role",
+			Id:       "does-not-exist",
+			RoleId:   "test-role",
+			Subjects: []string{"test-subject"},
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.NotFound))
@@ -247,8 +248,10 @@ var _ = Describe("Management API Rolebinding Management Tests", Ordered, Label("
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = client.UpdateRoleBinding(context.Background(), &corev1.RoleBinding{
-			Id:     "test-rolebinding8",
-			Taints: []string{"modified-taint"},
+			Id:       "test-rolebinding8",
+			RoleId:   "test-role",
+			Subjects: []string{"test-subject"},
+			Taints:   []string{"modified-taint"},
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))

--- a/test/integration/managementapi_roles_test.go
+++ b/test/integration/managementapi_roles_test.go
@@ -248,7 +248,8 @@ var _ = Describe("Management API Roles Management Tests", Ordered, Label("integr
 
 	It("cannot update a non existent role", func() {
 		_, err = client.UpdateRole(context.Background(), &corev1.Role{
-			Id: "does-not-exist",
+			Id:         "does-not-exist",
+			ClusterIDs: []string{"test-cluster"},
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.NotFound))


### PR DESCRIPTION
Since #1336 added new validations for roles and role bindings, this causes two tests intended to test 404s to error out with Invalid Argument instead of Not Found. Added the missing fields here