### PR TITLE
Distributed lock manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ internal/linter/*.so
 *.test
 **/__debug_bin
 *.out
+*.pprof
 .vscode
 .idea
 *.swp

--- a/pkg/storage/etcd/lock.go
+++ b/pkg/storage/etcd/lock.go
@@ -1,0 +1,95 @@
+package etcd
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+)
+
+type EtcdLock struct {
+	client  *clientv3.Client
+	mutex   *concurrency.Mutex
+	session *concurrency.Session
+
+	acquired uint32
+	key      string
+
+	startLock   lock.LockPrimitive
+	startUnlock lock.LockPrimitive
+	options     *lock.LockOptions
+}
+
+func NewEtcdLock(c *clientv3.Client, key string, options *lock.LockOptions) *EtcdLock {
+	lockValiditySeconds := int(options.LockValidity.Seconds())
+	if lockValiditySeconds == 0 {
+		lockValiditySeconds = 1
+	}
+	s, err := concurrency.NewSession(c, concurrency.WithTTL(lockValiditySeconds))
+	if err != nil {
+		panic(err)
+	}
+
+	m := concurrency.NewMutex(s, key)
+	return &EtcdLock{
+		client:  c,
+		session: s,
+		mutex:   m,
+		options: options,
+		key:     key,
+	}
+}
+
+var _ storage.Lock = (*EtcdLock)(nil)
+
+func (e *EtcdLock) Lock() error {
+	return e.startLock.Do(func() error {
+		ctxca, ca := context.WithCancel(e.client.Ctx())
+		signalAcquired := make(chan struct{})
+		defer close(signalAcquired)
+		if !e.options.Keepalive {
+			defer e.session.Orphan()
+		}
+		var lockErr error
+		var mu sync.Mutex
+		go func() {
+			select {
+			case <-e.options.AcquireContext.Done():
+				mu.Lock()
+				lockErr = errors.Join(lockErr, lock.ErrAcquireLockCancelled)
+				mu.Unlock()
+				ca()
+			case <-time.After(e.options.AcquireTimeout):
+				mu.Lock()
+				lockErr = errors.Join(lockErr, lock.ErrAcquireLockTimeout)
+				mu.Unlock()
+				ca()
+			}
+		}()
+		err := e.mutex.Lock(ctxca)
+		mu.Lock()
+		err = errors.Join(lockErr, err)
+		mu.Unlock()
+		if err != nil {
+			e.mutex.Unlock(e.client.Ctx())
+			return err
+		}
+		atomic.StoreUint32(&e.acquired, 1)
+		return nil
+	})
+}
+
+func (e *EtcdLock) Unlock() error {
+	return e.startUnlock.Do(func() error {
+		if atomic.LoadUint32(&e.acquired) == 0 {
+			return lock.ErrLockNotAcquired
+		}
+		return e.mutex.Unlock(e.client.Ctx())
+	})
+}

--- a/pkg/storage/etcd/lock_manager.go
+++ b/pkg/storage/etcd/lock_manager.go
@@ -1,0 +1,61 @@
+package etcd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	"github.com/rancher/opni/pkg/config/v1beta1"
+	"github.com/rancher/opni/pkg/logger"
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+	"github.com/rancher/opni/pkg/util"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+)
+
+type EtcdLockManager struct {
+	lg      *zap.SugaredLogger
+	options EtcdStoreOptions
+	client  *clientv3.Client
+}
+
+func NewEtcdLockManager(ctx context.Context, conf *v1beta1.EtcdStorageSpec, opts ...EtcdStoreOption) (*EtcdLockManager, error) {
+	options := EtcdStoreOptions{}
+	options.apply(opts...)
+	lg := logger.New(logger.WithLogLevel(zap.WarnLevel)).Named("etcd-locker")
+	var tlsConfig *tls.Config
+	if conf.Certs != nil {
+		var err error
+		tlsConfig, err = util.LoadClientMTLSConfig(conf.Certs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client TLS config: %w", err)
+		}
+	}
+	clientConfig := clientv3.Config{
+		Endpoints: conf.Endpoints,
+		TLS:       tlsConfig,
+		Context:   ctx,
+		Logger:    lg.Desugar(),
+	}
+	etcdClient, err := clientv3.New(clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create etcd client: %w", err)
+	}
+	lg.With(
+		"endpoints", clientConfig.Endpoints,
+	).Info("connecting to etcd")
+	return &EtcdLockManager{
+		options: options,
+		lg:      lg,
+		client:  etcdClient,
+	}, nil
+}
+
+var _ storage.LockManager = (*EtcdLockManager)(nil)
+
+func (e *EtcdLockManager) Locker(key string, opts ...lock.LockOption) storage.Lock {
+	options := lock.DefaultLockOptions(e.client.Ctx())
+	options.Apply(opts...)
+	return NewEtcdLock(e.client, key, options)
+}

--- a/pkg/storage/lock/lock.go
+++ b/pkg/storage/lock/lock.go
@@ -1,0 +1,114 @@
+package lock
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ErrAcquireLockTimeout        = errors.New("acquiring lock error: timeout")
+	ErrAcquireLockRetryExceeded  = errors.New("acquiring lock error: retry limit exceeded")
+	ErrAcquireLockCancelled      = errors.New("acquiring lock error: context cancelled")
+	ErrAcquireLockConflict       = errors.New("acquiring lock error: request has conflicting lock value")
+	ErrLockNotFound              = errors.New("lock not found")
+	ErrAcquireUnlockTimeout      = errors.New("acquiring unlock error: timeout")
+	ErrAcquireUnlockCancelled    = errors.New("acquiring unlock error: cancelled")
+	ErrAcquireUnockRetryExceeded = errors.New("acquiring unlock error: retry limit exceeded")
+	ErrLockNotAcquired           = errors.New("unlock failed: lock not acquired")
+
+	ErrLockActionRequested = errors.New("lock action already requested")
+)
+
+var (
+	DefaultRetryDelay     = 10 * time.Millisecond
+	DefaultAcquireTimeout = 100 * time.Millisecond
+	DefaultTimeout        = 10 * time.Second
+)
+
+// Modified sync.Once primitive
+type LockPrimitive struct {
+	done uint32
+	m    sync.Mutex
+}
+
+func (l *LockPrimitive) Do(f func() error) error {
+	if atomic.LoadUint32(&l.done) == 0 {
+		return l.doSlow(f)
+	}
+	return ErrLockActionRequested
+}
+
+func (l *LockPrimitive) doSlow(f func() error) error {
+	l.m.Lock()
+	defer l.m.Unlock()
+	if l.done == 0 {
+		defer atomic.StoreUint32(&l.done, 1)
+		return f()
+	}
+	return nil
+}
+
+type LockOptions struct {
+	// Upper time limit for acquiring locks
+	AcquireTimeout time.Duration
+	// Retry delay between lock attempts
+	RetryDelay time.Duration
+	// Custom context for acquiring the lock
+	AcquireContext context.Context
+	// Keepalive will keep the lock alive until the process running the lock exits,
+	// or the client connect context is done
+	Keepalive bool
+	// How long the remote lock stays valid for, if Keepalive is false
+	LockValidity time.Duration
+}
+
+func DefaultLockOptions(acquireCtx context.Context) *LockOptions {
+	return &LockOptions{
+		RetryDelay:     DefaultRetryDelay,
+		AcquireTimeout: DefaultAcquireTimeout,
+		LockValidity:   DefaultTimeout,
+		AcquireContext: acquireCtx,
+		Keepalive:      false,
+	}
+}
+
+func (o *LockOptions) Apply(opts ...LockOption) {
+	for _, op := range opts {
+		op(o)
+	}
+}
+
+type LockOption func(o *LockOptions)
+
+func WithRetryDelay(delay time.Duration) LockOption {
+	return func(o *LockOptions) {
+		o.RetryDelay = delay
+	}
+}
+
+func WithAcquireTimeout(timeout time.Duration) LockOption {
+	return func(o *LockOptions) {
+		o.AcquireTimeout = timeout
+	}
+}
+
+func WithExpireDuration(expireDuration time.Duration) LockOption {
+	return func(o *LockOptions) {
+		o.LockValidity = expireDuration
+	}
+}
+
+func WithAcquireContext(ctx context.Context) LockOption {
+	return func(o *LockOptions) {
+		o.AcquireContext = ctx
+	}
+}
+
+func WithKeepalive(keepalive bool) LockOption {
+	return func(o *LockOptions) {
+		o.Keepalive = keepalive
+	}
+}

--- a/pkg/storage/lock/lock_suite_test.go
+++ b/pkg/storage/lock/lock_suite_test.go
@@ -1,0 +1,14 @@
+package lock_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	_ "github.com/rancher/opni/pkg/test/setup"
+)
+
+func TestLock(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lock Suite")
+}

--- a/pkg/storage/lock/lock_test.go
+++ b/pkg/storage/lock/lock_test.go
@@ -1,0 +1,51 @@
+package lock_test
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/opni/pkg/storage/lock"
+)
+
+var _ = Describe("Lock", Label("unit"), func() {
+	When("using lock primtives", func() {
+		It("should run the lock primtive once", func() {
+			i := int32(0)
+			l := lock.LockPrimitive{}
+			l.Do(func() error {
+				atomic.AddInt32(&i, 1)
+				return nil
+			})
+			l.Do(func() error {
+				atomic.AddInt32(&i, 1)
+				return nil
+			})
+			Expect(i).To(Equal(int32(1)))
+		})
+
+		It("should return an error if the encapsulated function returns an error", func() {
+			l := lock.LockPrimitive{}
+			err := l.Do(func() error {
+				return fmt.Errorf("test error")
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("test error"))
+		})
+
+		It("should err if a lock primitive is run twice", func() {
+			l := lock.LockPrimitive{}
+			err := l.Do(func() error {
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = l.Do(func() error {
+				return nil
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(lock.ErrLockActionRequested))
+		})
+	})
+
+})

--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "github.com/rancher/opni/pkg/apis/core/v1"
 	"github.com/rancher/opni/pkg/keyring"
+	"github.com/rancher/opni/pkg/storage/lock"
 )
 
 type Backend interface {
@@ -85,6 +86,61 @@ type SubjectAccessCapableStore interface {
 }
 
 type WatchEventType string
+
+// Lock is a distributed lock that can be used to coordinate access to a resource.
+//
+// Locks are single use, and return errors when used more than once. Retry mechanisms are built into\
+// the Lock and can be configured with LockOptions.
+type Lock interface {
+	// Lock acquires a lock on the key. If the lock is already held, it will block until the lock is released.\
+	//
+	// Lock returns an error when acquiring the lock fails.
+	Lock() error
+	// Unlock releases the lock on the key. If the lock was never held, it will return an error.
+	Unlock() error
+}
+
+// LockManager replaces sync.Mutex when a distributed locking mechanism is required.
+//
+// # Usage
+//
+// ## Transient lock (transactions, tasks, ...)
+// ```
+//
+//		func distributedTransation(lm stores.LockManager, key string) error {
+//			keyMu := lm.Locker(key, lock.WithKeepalive(false), lock.WithExpireDuration(1 * time.Second))
+//			if err := keyMu.Lock(); err != nil {
+//			return err
+//			}
+//			defer keyMu.Unlock()
+//	     // do some work
+//		}
+//
+// ```
+//
+// ## Persistent lock (leader election)
+//
+// ```
+//
+//	func serve(lm stores.LockManager, key string, done chan struct{}) error {
+//		keyMu := lm.Locker(key, lock.WithKeepalive(true))
+//		if err := keyMu.Lock(); err != nil {
+//			return err
+//		}
+//		go func() {
+//			<-done
+//			keyMu.Unlock()
+//		}()
+//		// serve a service...
+//	}
+//
+// ```
+type LockManager interface {
+	// Instantiates a new Lock instance for the given key, with the given options.
+	//
+	// Defaults to lock.DefaultOptions if no options are provided.
+	Locker(key string, opts ...lock.LockOption) Lock
+}
 
 const (
 	WatchEventCreate WatchEventType = "PUT"

--- a/pkg/test/benchmark/storage/lock_bench.go
+++ b/pkg/test/benchmark/storage/lock_bench.go
@@ -1,0 +1,125 @@
+package benchmark_storage
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gmeasure"
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+	"github.com/rancher/opni/pkg/test/testruntime"
+	"github.com/rancher/opni/pkg/util/future"
+	"golang.org/x/sync/errgroup"
+)
+
+func LockManagerBenchmark[T storage.LockManager](
+	name string,
+	lmFs future.Future[[]T],
+) func() {
+	return func() {
+		var lms []T
+		BeforeAll(func() {
+			testruntime.IfCI(func() {
+				Skip("skipping lock benchmark in CI")
+			})
+			lms = lmFs.Get()
+		})
+
+		Context(fmt.Sprintf("Acquiring and releasing %s exclusive locks should be efficient", name), func() {
+			// == comment out this block for more accurate benchmarks
+			f, perr := os.Create(fmt.Sprintf("%s-single.pprof", name))
+			if perr != nil {
+				panic(perr)
+			}
+			pprof.StartCPUProfile(f)
+			defer pprof.StopCPUProfile()
+			// ==
+			Specify("within the same process", func() {
+				lm := lms[0]
+				expirement := gmeasure.NewExperiment("single process conflicting")
+				AddReportEntry(expirement.Name, expirement)
+
+				expirement.Sample(func(idx int) {
+					tcs := []int{10, 100}
+					for _, n := range tcs {
+						lockers := make([]storage.Lock, n)
+						for i := 0; i < n; i++ {
+							lockers[i] = lm.Locker("test", lock.WithAcquireTimeout(lock.DefaultTimeout), lock.WithRetryDelay(1*time.Microsecond))
+						}
+						expirementName := fmt.Sprintf("exclusive transactions %d", n)
+						expirement.MeasureDuration(expirementName, func() {
+							var eg errgroup.Group
+							for i := 0; i < n; i++ {
+								i := i
+								eg.Go(func() error {
+									defer lockers[i].Unlock()
+									return lockers[i].Lock()
+								})
+							}
+							err := eg.Wait()
+							Expect(err).NotTo(HaveOccurred())
+						})
+					}
+				}, gmeasure.SamplingConfig{N: 20, Duration: time.Minute})
+			})
+
+			Specify("accross multiple processes", func() {
+				// == comment out this block for more accurate benchmarks
+				f, perr := os.Create(fmt.Sprintf("%s-multiple.pprof", name))
+				if perr != nil {
+					panic(perr)
+				}
+				pprof.StartCPUProfile(f)
+				defer pprof.StopCPUProfile()
+				// ==
+				expirement := gmeasure.NewExperiment("multiple process conflicting")
+				AddReportEntry(expirement.Name, expirement)
+
+				expirement.Sample(func(idx int) {
+					type Testcase struct {
+						N int // number of processes
+						n int // number of locks per process
+					}
+					tcs := []Testcase{
+						{N: 3, n: 3},
+						{N: 5, n: 3},
+						{N: 7, n: 3},
+						// 100 distributed evenly per process
+						{N: 3, n: 100 / 3},
+						{N: 5, n: 100 / 5},
+						{N: 7, n: 100 / 7},
+					}
+					for _, tc := range tcs {
+						if len(lms) < tc.N {
+							Fail("not enough lock managers instantiated for benchmark")
+						}
+
+						lockers := make([]storage.Lock, tc.N*tc.n)
+
+						for i := 0; i < tc.N; i++ {
+							for j := 0; j < tc.n; j++ {
+								lockers[i*tc.n+j] = lms[i].Locker("test", lock.WithAcquireTimeout(lock.DefaultTimeout), lock.WithRetryDelay(1*time.Microsecond))
+							}
+						}
+						expirement.MeasureDuration(fmt.Sprintf("distributed exclusive transactions %dX%d", tc.N, tc.n), func() {
+							var eg errgroup.Group
+							for i := 0; i < len(lockers); i++ {
+								i := i
+								eg.Go(func() error {
+									defer lockers[i].Unlock()
+									return lockers[i].Lock()
+								})
+							}
+							err := eg.Wait()
+							Expect(err).NotTo(HaveOccurred())
+						})
+					}
+				}, gmeasure.SamplingConfig{N: 10, Duration: time.Minute})
+			})
+		})
+	}
+}

--- a/pkg/test/benchmark/storage/storage_suite_test.go
+++ b/pkg/test/benchmark/storage/storage_suite_test.go
@@ -1,0 +1,47 @@
+package benchmark_storage
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/opni/pkg/storage/etcd"
+	"github.com/rancher/opni/pkg/test"
+	_ "github.com/rancher/opni/pkg/test/setup"
+	"github.com/rancher/opni/pkg/test/testruntime"
+	"github.com/rancher/opni/pkg/util/future"
+)
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Storage Suite")
+}
+
+var lmsEtcdF = future.New[[]*etcd.EtcdLockManager]()
+
+var _ = BeforeSuite(func() {
+	testruntime.IfIntegration(func() {
+		env := test.Environment{}
+		env.Start(
+			test.WithEnableGateway(false),
+			test.WithEnableEtcd(true),
+			test.WithEnableJetstream(false),
+		)
+
+		lmsE := make([]*etcd.EtcdLockManager, 7)
+		for i := 0; i < 7; i++ {
+			l, err := etcd.NewEtcdLockManager(context.Background(), env.EtcdConfig(),
+				etcd.WithPrefix("test"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			lmsE[i] = l
+		}
+
+		lmsEtcdF.Set(lmsE)
+		// lmsJetstreamF.Set(lmsJ)
+		DeferCleanup(env.Stop)
+	})
+})
+
+var _ = Describe("Etcd lock manager", Ordered, Serial, Label("integration", "slow"), LockManagerBenchmark("etcd", lmsEtcdF))

--- a/pkg/test/conformance/storage/lock_helpers.go
+++ b/pkg/test/conformance/storage/lock_helpers.go
@@ -1,0 +1,227 @@
+package conformance_storage
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+	"github.com/samber/lo"
+)
+
+// Timeouts are only valid if we specified lock.Keeplive(false)
+func expectTimeout(lm storage.LockManager) error {
+	lock1 := lm.Locker("bar", lock.WithKeepalive(false), lock.WithAcquireTimeout(time.Second), lock.WithExpireDuration(5*time.Second))
+	lock2 := lm.Locker("bar")
+
+	err := lock1.Lock()
+	if err != nil {
+		return err
+	}
+
+	err = lock2.Lock()
+	if !errors.Is(err, lock.ErrAcquireLockTimeout) {
+		return fmt.Errorf("expected lock to timeout, but got %v", err)
+	}
+
+	err = lock2.Unlock()
+	if !errors.Is(err, lock.ErrLockNotAcquired) {
+		return fmt.Errorf("expected unlock to fail, but got %v", err)
+	}
+
+	return lock1.Unlock()
+}
+
+func expectCancellable(lm storage.LockManager) error {
+	ctxca, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	exLock := lm.Locker("bar", lock.WithExpireDuration(time.Hour))
+	cancelLock := lm.Locker("bar", lock.WithAcquireContext(ctxca), lock.WithRetryDelay(time.Microsecond*500))
+	err := exLock.Lock()
+	if err != nil {
+		return err
+	}
+	go func() {
+		time.Sleep(500 * time.Microsecond)
+		cancel()
+	}()
+	err = cancelLock.Lock()
+	if !errors.Is(err, lock.ErrAcquireLockCancelled) {
+		return fmt.Errorf("expected lock to be cancelled, but got %v", err)
+	}
+
+	err = cancelLock.Unlock()
+	if !errors.Is(err, lock.ErrLockNotAcquired) {
+		return fmt.Errorf("expected unlock to fail, but got %v", err)
+	}
+	return exLock.Unlock()
+
+}
+
+type lockWithTransaction lo.Tuple3[storage.Lock, *transaction, chan struct{}]
+
+// Sequential execution is guaranteed by :
+// - first starting a lock
+// - having multiple candidate locks try and concurrently acquire the lock
+// - when the first lock is released, only one of the candidate locks should be able to acquire the lock
+func expectAtomic(lock1 storage.Lock, lockConstructor func(opts ...lock.LockOption) storage.Lock) error {
+	err := lock1.Lock()
+	Expect(err).NotTo(HaveOccurred())
+
+	otherLocks := []storage.Lock{
+		lockConstructor(lock.WithExpireDuration(time.Second), lock.WithAcquireTimeout(150*time.Millisecond)),
+		lockConstructor(lock.WithExpireDuration(time.Second), lock.WithAcquireTimeout(150*time.Millisecond)),
+		lockConstructor(lock.WithExpireDuration(time.Second), lock.WithAcquireTimeout(150*time.Millisecond)),
+	}
+
+	var numLocksAcquired uint32
+	var numLocksTimeouted uint32
+	var tasksSpawned uint32
+	expectedTasks := len(otherLocks)
+
+	var wg sync.WaitGroup
+	var toUnlock storage.Lock
+
+	wg.Add(2)
+
+	go func() {
+		var nestedWg sync.WaitGroup
+		defer wg.Done()
+		defer GinkgoRecover()
+		nestedWg.Add(len(otherLocks))
+		for _, olock := range otherLocks {
+			olock := olock
+			go func() {
+				defer nestedWg.Done()
+				atomic.AddUint32(&tasksSpawned, 1)
+				err := olock.Lock()
+				if err == nil {
+					atomic.AddUint32(&numLocksAcquired, 1)
+					toUnlock = olock
+				}
+				if errors.Is(err, lock.ErrAcquireLockTimeout) {
+					atomic.AddUint32(&numLocksTimeouted, 1)
+				}
+			}()
+		}
+		nestedWg.Wait()
+
+	}()
+
+	go func() {
+		for {
+			tasks := atomic.LoadUint32(&tasksSpawned)
+			if tasks == uint32(expectedTasks) {
+				break
+			}
+		}
+		defer GinkgoRecover()
+		lock1.Unlock()
+		defer wg.Done()
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	wg.Wait()
+	if toUnlock == nil {
+		return fmt.Errorf("expected one of the locks to be acquired, but none were (%d timeouted)", numLocksTimeouted)
+	}
+	if err := toUnlock.Unlock(); err != nil {
+		return err
+	}
+	Expect(err).NotTo(HaveOccurred())
+	if numLocksAcquired != 1 {
+		return fmt.Errorf("expected only one lock to be acquired, but got %d", numLocksAcquired)
+	}
+	if numLocksTimeouted != uint32(len(otherLocks)-1) {
+		return fmt.Errorf("expected %d locks to timeout, but got %d", len(otherLocks)-1, numLocksTimeouted)
+	}
+	return nil
+}
+
+func expectAtomicKeepAlive(lock1 storage.Lock, lockConstructor func(opts ...lock.LockOption) storage.Lock) error {
+	err := lock1.Lock()
+	Expect(err).NotTo(HaveOccurred())
+
+	otherLocks := []storage.Lock{
+		// some implementations expire durations are forced to round up to the largest second, so 2 *time.Second is a requirement here
+		lockConstructor(lock.WithExpireDuration(time.Second), lock.WithAcquireTimeout(2*time.Second)),
+		lockConstructor(lock.WithExpireDuration(time.Second), lock.WithAcquireTimeout(2*time.Second)),
+		lockConstructor(lock.WithExpireDuration(time.Second), lock.WithAcquireTimeout(2*time.Second)),
+	}
+
+	var numLocksAcquired uint32
+	var numLocksTimeouted uint32
+	var tasksSpawned uint32
+	expectedTasks := len(otherLocks)
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		var nestedWg sync.WaitGroup
+		defer wg.Done()
+		defer GinkgoRecover()
+		nestedWg.Add(len(otherLocks))
+		for _, olock := range otherLocks {
+			olock := olock
+			go func() {
+				defer nestedWg.Done()
+				atomic.AddUint32(&tasksSpawned, 1)
+				err := olock.Lock()
+				if err == nil {
+					atomic.AddUint32(&numLocksAcquired, 1)
+				}
+				if errors.Is(err, lock.ErrAcquireLockTimeout) {
+					atomic.AddUint32(&numLocksTimeouted, 1)
+				}
+			}()
+		}
+		nestedWg.Wait()
+
+	}()
+
+	go func() {
+		defer wg.Done()
+		for {
+			tasks := atomic.LoadUint32(&tasksSpawned)
+			if tasks == uint32(expectedTasks) {
+				break
+			}
+		}
+	}()
+
+	wg.Wait()
+	Expect(err).NotTo(HaveOccurred())
+	if numLocksAcquired != 0 {
+		return fmt.Errorf("expected no locks to be acquired, but got %d", numLocksAcquired)
+	}
+	if numLocksTimeouted != uint32(len(otherLocks)) {
+		return fmt.Errorf("expected all %d locks to timeout, but got %d", len(otherLocks), numLocksTimeouted)
+	}
+	return nil
+}
+
+type transaction struct {
+	Uuid string
+}
+
+func jitter() time.Duration {
+	rand.NewSource(time.Now().UnixNano())
+	randomMicroseconds := rand.Intn(101)
+	jitterInterval := time.Duration(randomMicroseconds) * time.Microsecond
+	return jitterInterval
+}
+
+func sendWithJitter(send chan struct{}) {
+	<-time.After(jitter())
+	send <- struct{}{}
+}

--- a/pkg/test/conformance/storage/lock_manager.go
+++ b/pkg/test/conformance/storage/lock_manager.go
@@ -1,0 +1,132 @@
+package conformance_storage
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+	"github.com/rancher/opni/pkg/util/future"
+	"github.com/samber/lo"
+)
+
+func LockManagerTestSuite[T storage.LockManager](
+	lmF future.Future[T],
+) func() {
+	return func() {
+		var lm T
+		BeforeAll(func() {
+			lm = lmF.Get()
+		})
+
+		When("using distributed locks ", func() {
+			It("should only request lock actions once", func() {
+				lock1 := lm.Locker("foo")
+				err := lock1.Lock()
+				Expect(err).NotTo(HaveOccurred())
+				err = lock1.Lock()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(lock.ErrLockActionRequested))
+
+				err = lock1.Unlock()
+				Expect(err).NotTo(HaveOccurred())
+				err = lock1.Unlock()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(lock.ErrLockActionRequested))
+			})
+
+			It("should lock and unlock locks of the same type", func() {
+				lock1 := lm.Locker("todo")
+				Expect(lock1.Lock()).To(Succeed())
+				Expect(lock1.Unlock()).To(Succeed())
+
+				lock2 := lm.Locker("todo")
+				Expect(lock2.Lock()).To(Succeed())
+				Expect(lock2.Unlock()).To(Succeed())
+			})
+			It("should resolve concurrent lock requests", func() {
+				locks := []lockWithTransaction{}
+				for i := 0; i < 2; i++ {
+					lock := lm.Locker("todo")
+					locks = append(locks, lockWithTransaction{
+						A: lock,
+						C: make(chan struct{}),
+					})
+				}
+				errs := make(chan error, 2*len(locks))
+
+				lockOrder := lo.Shuffle(locks)
+				var wg sync.WaitGroup
+				for _, lock := range lockOrder {
+					lock := lock
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						err := lock.A.Lock()
+						sendWithJitter(lock.C)
+						errs <- err
+					}()
+				}
+				for _, lock := range lockOrder {
+					lock := lock
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						<-lock.C
+						errs <- lock.A.Unlock()
+					}()
+				}
+				wg.Wait()
+				Eventually(errs).Should(Receive(BeNil()))
+			})
+
+			Specify("locks should be able to acquire the lock if the existing lock has expired", func() {
+				exLock := lm.Locker("bar", lock.WithRetryDelay(1*time.Millisecond), lock.WithExpireDuration(0*time.Second))
+				// some implementations expire durations are forced to round up to the largest second, so 3 *time.Second is a requirement here
+				otherLock := lm.Locker("bar", lock.WithAcquireTimeout(3*time.Second))
+				err := exLock.Lock()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = otherLock.Lock()
+				Expect(err).NotTo(HaveOccurred())
+
+				By("releasing the expired exclusive lock should not affect releasing newer locks")
+				err = exLock.Unlock()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = otherLock.Unlock()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Specify("any lock should timeout after the specified timeout", func() {
+				Expect(expectTimeout(lm)).To(Succeed())
+			})
+
+			Specify("lock should respect their context errors", func() {
+				Expect(expectCancellable(lm)).To(Succeed())
+			})
+		})
+
+		When("using exclusive locks in process", func() {
+			It("should allow multiple exclusive writers to safely write using locks", func() {
+				lock1 := lm.Locker("foo2", lock.WithKeepalive(false), lock.WithExpireDuration(0*time.Second))
+				err := expectAtomic(lock1, func(opts ...lock.LockOption) storage.Lock {
+					return lm.Locker("foo2", opts...)
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should block other locks from acquiring the lock if the process holding the lock is alive", func() {
+				lock1 := lm.Locker("foo3", lock.WithKeepalive(true), lock.WithExpireDuration(0*time.Second))
+				err := expectAtomicKeepAlive(lock1, func(opts ...lock.LockOption) storage.Lock {
+					return lm.Locker("foo3", opts...)
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+	}
+}


### PR DESCRIPTION
Includes:
- [x] `LockManager` interface : builder for acquiring locks scoped to keys. replaces sync.Mutex where distributed access is required, for example: 

```go
type A struct {
  mu sync.Mutex
}
```
should become

```go
type A struct {
  mu stores.LockManager
}
```

and NOT

```go
type A struct {
  mu stores.Lock
}
```

- [x] `Lock interface` : distributed mutex (single use only)
  - Implementation details for the Lock can be injected via `LockOptions`
- [x] `LockOptions` (important ones below):
  - `WithKeepalive` : keeps the lock alive as long as the process owning the lock is still running, or unlock is called
    - typical usecases: leader election
  - `WithExpireDuration` : fallback to set a hard limit on expiry, if we opt-out of keepalive semantics
    - typical usecase : transaction or task that requires distributed locking
- [x] Etcd implementation
- [x] Exclusive lock & Lock manager conformance tests
- [x] Benchmark tests for lock manager implementations

Does not include a jetstream implementation (yet), due to:
- scalability concerns with the current jetstream version < v2.10
- expiry semantics with jetstream
