### PR TITLE
Fix open telemetry config from UI

### DIFF
--- a/web/pkg/opni/utils/requests/node-configuration.ts
+++ b/web/pkg/opni/utils/requests/node-configuration.ts
@@ -19,5 +19,5 @@ const PROMETHEUS_CONFIG = {
 
 const OTEL_CONFIG = {
   rules:  { discovery: { prometheusRules: {} } },
-  otel:  { hostMetrics: true }
+  otel:  { hostMetrics: false }
 };


### PR DESCRIPTION
This is causing a ton of extra overhead from an experimental feature with otel metrics that is not production ready yet