### PR TITLE
Add noop updates for support agent

### DIFF
--- a/pkg/opni/commands/gateway.go
+++ b/pkg/opni/commands/gateway.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher/opni/pkg/plugins/hooks"
 	"github.com/rancher/opni/pkg/tracing"
 	"github.com/rancher/opni/pkg/update/noop"
-	"github.com/rancher/opni/pkg/urn"
 	"github.com/rancher/opni/pkg/util/waitctx"
 	"github.com/spf13/cobra"
 	"github.com/ttacon/chalk"
@@ -105,7 +104,7 @@ func BuildGatewayCmd() *cobra.Command {
 		lifecycler := config.NewLifecycler(objects)
 		g := gateway.NewGateway(ctx, gatewayConfig, pluginLoader,
 			gateway.WithLifecycler(lifecycler),
-			gateway.WithExtraUpdateHandlers(noop.NewSyncServer(noop.WithAllowedTypes(urn.Agent))),
+			gateway.WithExtraUpdateHandlers(noop.NewSyncServer()),
 		)
 
 		m := management.NewServer(ctx, &gatewayConfig.Spec.Management, g, pluginLoader,

--- a/pkg/update/syncer.go
+++ b/pkg/update/syncer.go
@@ -1,0 +1,66 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	controlv1 "github.com/rancher/opni/pkg/apis/control/v1"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+)
+
+type SyncConfig struct {
+	Client controlv1.UpdateSyncClient
+	Syncer SyncHandler
+	Logger *zap.SugaredLogger
+}
+
+func (conf SyncConfig) DoSync(ctx context.Context) error {
+	syncer := conf.Syncer
+	initialManifest, err := getManifestWithTimeout(ctx, syncer)
+	if err != nil {
+		return err
+	}
+	updateType, err := GetType(initialManifest.GetItems())
+	if err != nil {
+		return fmt.Errorf("failed to get manifest update type: %w", err)
+	}
+
+	lg := conf.Logger.With(
+		zap.String("type", string(updateType)),
+	)
+	lg.With(
+		"entries", len(initialManifest.GetItems()),
+	).Debug("sending manifest sync request")
+
+	syncResp, err := conf.Client.SyncManifest(metadata.AppendToOutgoingContext(ctx,
+		controlv1.UpdateStrategyKeyForType(updateType), syncer.Strategy(),
+	), initialManifest)
+	if err != nil {
+		return fmt.Errorf("failed to sync agent manifest: %w", err)
+	}
+	lg.Info("received sync response")
+	err = syncer.HandleSyncResults(ctx, syncResp)
+	if err != nil {
+		return fmt.Errorf("failed to handle agent sync results: %w", err)
+	}
+	lg.With(
+		"entries", len(initialManifest.GetItems()),
+	).Info("manifest sync complete")
+	return nil
+}
+
+func (conf SyncConfig) Result(ctx context.Context) (*controlv1.UpdateManifest, error) {
+	return getManifestWithTimeout(ctx, conf.Syncer)
+}
+
+func getManifestWithTimeout(ctx context.Context, syncer SyncHandler) (*controlv1.UpdateManifest, error) {
+	ctx, ca := context.WithTimeout(ctx, 10*time.Second)
+	m, err := syncer.GetCurrentManifest(ctx)
+	ca()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current manifest: %w", err)
+	}
+	return m, nil
+}


### PR DESCRIPTION
Moves the update syncer and exports it to make it reusable. 
Add noop updater to the support plugin.