### PR TITLE
Add storage extension to save filelog receivers' offsets

### DIFF
--- a/pkg/resources/collector/templates.go
+++ b/pkg/resources/collector/templates.go
@@ -232,7 +232,7 @@ processors:
     {{ template "metrics-system-processor" . }}
 extensions:
   file_storage:
-    directory: /etc/otel/filestorage
+    directory: /var/otel/filestorage
     timeout: 1s
 service:
   extensions: [file_storage]

--- a/pkg/resources/collector/templates.go
+++ b/pkg/resources/collector/templates.go
@@ -106,7 +106,7 @@ journald/k3s:
 	templateKubeAuditLogs = template.Must(template.New("kubeauditlogsreceiver").Parse(`
 filelog/kubeauditlogs:
   include: [ {{ . }} ]
-  start_at: beginning
+  storage: file_storage
   include_file_path: false
   include_file_name: false
   operators:

--- a/pkg/resources/collector/templates.go
+++ b/pkg/resources/collector/templates.go
@@ -19,7 +19,7 @@ var (
 filelog/k8s:
   include: [ /var/log/pods/*/*/*.log ]
   exclude: []
-  start_at: beginning
+  storage: file_storage
   include_file_path: true
   include_file_name: false
   operators:
@@ -87,7 +87,7 @@ filelog/k8s:
 	templateLogAgentRKE = `
 filelog/rke:
   include: [ /var/lib/rancher/rke/log/*.log ]
-  start_at: beginning
+  storage: file_storage
   include_file_path: true
   include_file_name: false
   operators:
@@ -157,7 +157,7 @@ journald/rke2:
   directory: {{ . }}
 filelog/rke2:
   include: [ /var/lib/rancher/rke2/agent/logs/kubelet.log ]
-  start_at: beginning
+  storage: file_storage
   include_file_path: true
   include_file_name: false
   operators:
@@ -230,7 +230,12 @@ processors:
       - key: tier
       - key: component
     {{ template "metrics-system-processor" . }}
+extensions:
+  file_storage:
+    directory: /etc/otel/filestorage
+    timeout: 1s
 service:
+  extensions: [file_storage]
   telemetry:
     logs:
       level: {{ .LogLevel }}

--- a/pkg/resources/collector/workloads.go
+++ b/pkg/resources/collector/workloads.go
@@ -30,7 +30,7 @@ const (
 	collectorImage     = "rancher-sandbox/opni-otel-collector"
 	collectorVersion   = "v0.1.4-rc1-0.85.0"
 	reloaderImage      = "rancher-sandbox/config-reloader"
-	reloaderVersion    = "v0.1.4-rc1-0.85.0"
+	reloaderVersion    = "v0.1.2"
 
 	otelColBinaryName  = "otelcol-custom"
 	otelConfigDir      = "/etc/otel"

--- a/pkg/resources/collector/workloads.go
+++ b/pkg/resources/collector/workloads.go
@@ -34,7 +34,7 @@ const (
 
 	otelColBinaryName  = "otelcol-custom"
 	otelConfigDir      = "/etc/otel"
-	otelFileStorageDir = "/etc/otel/filestorage"
+	otelFileStorageDir = "/var/otel/filestorage"
 
 	otlpGRPCPort    = int32(4317)
 	rke2AgentLogDir = "/var/lib/rancher/rke2/agent/logs/"

--- a/pkg/resources/collector/workloads.go
+++ b/pkg/resources/collector/workloads.go
@@ -26,14 +26,11 @@ const (
 	mainKey       = "config.yaml"
 	aggregatorKey = "aggregator.yaml"
 
-	// TODO(jaehnri): update when https://github.com/rancher-sandbox/opni-otel-collector/pull/13 is merged
-	collectorImageRepo = "docker.io"
-	collectorImage     = "jaehnri/otel-collector"
-	collectorVersion   = "latest"
-
-	reloaderImageRepo = "ghcr.io"
-	reloaderImage     = "rancher-sandbox/config-reloader"
-	reloaderVersion   = "v0.1.2"
+	collectorImageRepo = "ghcr.io"
+	collectorImage     = "rancher-sandbox/opni-otel-collector"
+	collectorVersion   = "v0.1.4-rc1-0.85.0"
+	reloaderImage      = "rancher-sandbox/config-reloader"
+	reloaderVersion    = "v0.1.4-rc1-0.85.0"
 
 	otelColBinaryName  = "otelcol-custom"
 	otelConfigDir      = "/etc/otel"
@@ -586,7 +583,7 @@ func (r *Reconciler) configReloaderImageSpec() opnimeta.ImageSpec {
 	return opnimeta.ImageResolver{
 		Version:     reloaderVersion,
 		ImageName:   reloaderImage,
-		DefaultRepo: reloaderImageRepo,
+		DefaultRepo: collectorImageRepo,
 		ImageOverride: func() *opnimeta.ImageSpec {
 			if r.collector.Spec.ConfigReloader != nil {
 				return &r.collector.Spec.ConfigReloader.ImageSpec

--- a/pkg/resources/preprocessor/workloads.go
+++ b/pkg/resources/preprocessor/workloads.go
@@ -21,9 +21,9 @@ import (
 
 const (
 	configKey             = "config.yaml"
-	preprocessorVersion   = "v0.1.3-rc2-0.74.0"
-	preprocessorImageRepo = "ghcr.io/rancher-sandbox"
-	preprocessorImage     = "opni-otel-collector"
+	preprocessorVersion   = "latest"
+	preprocessorImageRepo = "docker.io/jaehnri"
+	preprocessorImage     = "otel-collector"
 	otlpGRPCPort          = 4317
 )
 

--- a/pkg/resources/preprocessor/workloads.go
+++ b/pkg/resources/preprocessor/workloads.go
@@ -70,7 +70,6 @@ processors:
     log_statements:
     - context: log
       statements:
-      - merge_maps(attributes, body, "upsert") where attributes["filename"] == nil
       - set(attributes["COMM"], attributes["_COMM"])
       - delete_matching_keys(attributes, "^_.*")
     - context: resource

--- a/pkg/resources/preprocessor/workloads.go
+++ b/pkg/resources/preprocessor/workloads.go
@@ -21,9 +21,9 @@ import (
 
 const (
 	configKey             = "config.yaml"
-	preprocessorVersion   = "latest"
-	preprocessorImageRepo = "docker.io/jaehnri"
-	preprocessorImage     = "otel-collector"
+	preprocessorVersion   = "v0.1.4-rc1-0.85.0"
+	preprocessorImageRepo = "ghcr.io/rancher-sandbox"
+	preprocessorImage     = "opni-otel-collector"
 	otlpGRPCPort          = 4317
 )
 

--- a/plugins/logging/pkg/agent/drivers/kubernetes_manager/kubernetes_manager.go
+++ b/plugins/logging/pkg/agent/drivers/kubernetes_manager/kubernetes_manager.go
@@ -153,7 +153,7 @@ func (m *KubernetesManagerDriver) buildLoggingCollectorConfig() *opniloggingv1be
 		Spec: opniloggingv1beta1.CollectorConfigSpec{
 			Provider: opniloggingv1beta1.LogProvider(m.provider),
 			KubeAuditLogs: &opniloggingv1beta1.KubeAuditLogsSpec{
-				Enabled: true,
+				Enabled: false,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #1708 

The `filestorage` extension allows us to keep track of the tail offset for every log file watched by the `filelog` receivers. This way, whenever an `opni-collector-agent` pod restarts, they can continue reading the log files from where they stopped.

Previously, whenever a crash or restart happened, agents would read from the start again, sending repeated logs and causing an overflow in the aggregator queues:
```
2023-09-20T14:18:42.911Z	error	exporterhelper/queued_retry.go:216	Dropping data because sending_queue is full. Try increasing queue_size.	{"kind": "exporter", "data_type": "logs", "name": "otlp", "dropped_items": 100}
```

Now, on restarts, this is logged to the `opni-collector-agents`:
```
2023-09-20T15:42:14.081Z	info	extensions/extensions.go:31	Starting extensions...
2023-09-20T15:42:14.081Z	info	extensions/extensions.go:34	Extension is starting...	{"kind": "extension", "name": "file_storage"}
2023-09-20T15:42:14.082Z	info	extensions/extensions.go:38	Extension started.	{"kind": "extension", "name": "file_storage"}
2023-09-20T15:42:14.083Z	info	adapter/receiver.go:45	Starting stanza receiver	{"kind": "receiver", "name": "filelog/k8s", "data_type": "logs"}
2023-09-20T15:42:14.084Z	info	fileconsumer/file.go:354	Resuming from previously known offset(s). 'start_at' setting is not applicable.	{"kind": "receiver", "name": "filelog/k8s", "data_type": "logs", "component": "fileconsumer"}
```

Also, I disabled the audit logs by default as `rancher-logging` does.