### PR TITLE
Jetstream Lock implementation

### DIFF
--- a/pkg/storage/jetstream/jetstream_suite_test.go
+++ b/pkg/storage/jetstream/jetstream_suite_test.go
@@ -22,6 +22,7 @@ func TestJetStream(t *testing.T) {
 }
 
 var store = future.New[*jetstream.JetStreamStore]()
+var lmF = future.New[*jetstream.LockManager]()
 
 var _ = BeforeSuite(func() {
 	testruntime.IfIntegration(func() {
@@ -36,6 +37,10 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 		store.Set(s)
 
+		lm, err := jetstream.NewJetstreamLockManager(context.Background(), env.JetStreamConfig())
+		Expect(err).NotTo(HaveOccurred())
+		lmF.Set(lm)
+
 		DeferCleanup(env.Stop, "Test Suite Finished")
 	})
 })
@@ -45,6 +50,7 @@ var _ = Describe("Jetstream Cluster Store", Ordered, Label("integration", "slow"
 var _ = Describe("Jetstream RBAC Store", Ordered, Label("integration", "slow"), RBACStoreTestSuite(store))
 var _ = Describe("Jetstream Keyring Store", Ordered, Label("integration", "slow"), KeyringStoreTestSuite(store))
 var _ = Describe("Jetstream KV Store", Ordered, Label("integration", "slow"), KeyValueStoreTestSuite(store, NewBytes, Equal))
+var _ = Describe("Jetstream Lock Manager", Ordered, Label("integration", "slow"), LockManagerTestSuite(lmF))
 
 var _ = Context("Error Codes", func() {
 	Specify("Nats KeyNotFound errors should be equal to ErrNotFound", func() {

--- a/pkg/storage/jetstream/lock.go
+++ b/pkg/storage/jetstream/lock.go
@@ -1,0 +1,172 @@
+package jetstream
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+)
+
+func newLease(key string) *nats.StreamConfig {
+	return &nats.StreamConfig{
+		Name:         key,
+		Retention:    nats.InterestPolicy,
+		Subjects:     []string{fmt.Sprintf("%s.lease.*", key)},
+		MaxConsumers: 1,
+	}
+}
+
+type Lock struct {
+	key  string
+	uuid string
+
+	acquired uint32
+
+	js   nats.JetStreamContext
+	sub  *nats.Subscription
+	msgQ chan *nats.Msg
+	*lock.LockOptions
+
+	startLock   lock.LockPrimitive
+	startUnlock lock.LockPrimitive
+}
+
+var _ storage.Lock = (*Lock)(nil)
+
+func NewLock(js nats.JetStreamContext, key string, options *lock.LockOptions) *Lock {
+	return &Lock{
+		key:         key,
+		js:          js,
+		uuid:        uuid.New().String(),
+		msgQ:        make(chan *nats.Msg, 16),
+		LockOptions: options,
+	}
+}
+
+func (l *Lock) Lock() error {
+
+	return l.startLock.Do(func() error {
+		return l.lock()
+	})
+}
+
+func (l *Lock) lock() error {
+	timeout := time.After(l.AcquireTimeout)
+	tTicker := time.NewTicker(l.RetryDelay)
+	defer tTicker.Stop()
+
+	var lockErr error
+	for {
+		select {
+		case <-tTicker.C:
+			err := l.tryLock()
+			if err == nil {
+				return nil
+			}
+			lockErr = err
+		case <-l.AcquireContext.Done():
+			return errors.Join(lock.ErrAcquireLockCancelled, lockErr)
+		case <-timeout:
+			return errors.Join(lockErr, lock.ErrAcquireLockTimeout)
+		}
+	}
+}
+
+func (l *Lock) tryLock() error {
+	var err error
+	if _, err := l.js.AddStream(newLease(l.key)); err != nil {
+		return err
+	}
+	cfg := &nats.ConsumerConfig{
+		Durable:           l.uuid,
+		AckPolicy:         nats.AckExplicitPolicy,
+		InactiveThreshold: l.LockValidity,
+		DeliverSubject:    l.uuid,
+	}
+	if l.Keepalive {
+		// Push-based details, defaults to 5 * time.Second
+		cfg.Heartbeat = max(l.RetryDelay, 100*time.Millisecond)
+	}
+
+	if _, err := l.js.AddConsumer(l.key, cfg); err != nil {
+		return err
+	}
+	l.sub, err = l.js.ChanSubscribe(l.uuid, l.msgQ, nats.Bind(l.key, l.uuid))
+	if err != nil {
+		return err
+	}
+	go l.keepalive()
+	go l.expire()
+	atomic.StoreUint32(&l.acquired, 1)
+	return nil
+}
+
+func (l *Lock) expire() {
+	if l.Keepalive {
+		return
+	}
+	timeout := time.After(l.LockValidity)
+	<-timeout
+	l.unlock()
+}
+
+func (l *Lock) keepalive() {
+	if !l.Keepalive {
+		return
+	}
+	for msg := range l.msgQ {
+		msg.Ack()
+	}
+}
+
+func (l *Lock) Unlock() error {
+	return l.startUnlock.Do(func() error {
+		if atomic.LoadUint32(&l.acquired) == 0 {
+			return lock.ErrLockNotAcquired
+		}
+		return l.unlock()
+	})
+}
+
+func (l *Lock) unlock() error {
+	timeout := time.After(l.AcquireTimeout)
+	tTicker := time.NewTicker(l.RetryDelay)
+	defer tTicker.Stop()
+
+	var unlockErr error
+	for {
+		select {
+		case <-tTicker.C:
+			err := l.tryUnlock()
+			if err == nil {
+				return nil
+			}
+			unlockErr = err
+		case <-l.AcquireContext.Done():
+			return errors.Join(lock.ErrAcquireUnlockCancelled, unlockErr)
+		case <-timeout:
+			return errors.Join(lock.ErrAcquireUnlockTimeout, unlockErr)
+		}
+	}
+}
+
+func (l *Lock) tryUnlock() error {
+	if err := l.sub.Unsubscribe(); err != nil {
+		if errors.Is(err, nats.ErrBadSubscription) || errors.Is(err, nats.ErrConsumerNotActive) { // lock already released
+			return nil
+		}
+		return err
+	}
+	if err := l.js.DeleteConsumer(l.key, l.uuid); err != nil {
+		if errors.Is(err, nats.ErrConsumerNotFound) || errors.Is(err, nats.ErrConsumerNotActive) { // lock already released
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/pkg/storage/jetstream/lock_manager.go
+++ b/pkg/storage/jetstream/lock_manager.go
@@ -1,0 +1,97 @@
+package jetstream
+
+import (
+	"context"
+	"time"
+
+	"github.com/lestrrat-go/backoff/v2"
+	"github.com/nats-io/nats.go"
+	"github.com/rancher/opni/pkg/config/v1beta1"
+	"github.com/rancher/opni/pkg/logger"
+	"github.com/rancher/opni/pkg/storage"
+	"github.com/rancher/opni/pkg/storage/lock"
+	"go.uber.org/zap"
+)
+
+// Requires jetstream 2.9+
+type LockManager struct {
+	ctx context.Context
+	js  nats.JetStreamContext
+}
+
+// Requires jetstream 2.9+
+func NewJetstreamLockManager(ctx context.Context, conf *v1beta1.JetStreamStorageSpec, opts ...JetStreamStoreOption) (*LockManager, error) {
+	options := JetStreamStoreOptions{
+		BucketPrefix: "gateway",
+	}
+	options.apply(opts...)
+
+	lg := logger.New(logger.WithLogLevel(zap.WarnLevel)).Named("jetstream")
+
+	nkeyOpt, err := nats.NkeyOptionFromSeed(conf.NkeySeedPath)
+	if err != nil {
+		return nil, err
+	}
+	nc, err := nats.Connect(conf.Endpoint,
+		nkeyOpt,
+		nats.MaxReconnects(-1),
+		nats.RetryOnFailedConnect(true),
+		nats.DisconnectErrHandler(func(c *nats.Conn, err error) {
+			lg.With(
+				zap.Error(err),
+			).Warn("disconnected from jetstream")
+		}),
+		nats.ReconnectHandler(func(c *nats.Conn) {
+			lg.With(
+				"server", c.ConnectedAddr(),
+				"id", c.ConnectedServerId(),
+				"name", c.ConnectedServerName(),
+				"version", c.ConnectedServerVersion(),
+			).Info("reconnected to jetstream")
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+		nc.Close()
+	}()
+
+	ctrl := backoff.Exponential(
+		backoff.WithMaxRetries(0),
+		backoff.WithMinInterval(10*time.Millisecond),
+		backoff.WithMaxInterval(10*time.Millisecond<<9),
+		backoff.WithMultiplier(2.0),
+	).Start(ctx)
+	for {
+		if rtt, err := nc.RTT(); err == nil {
+			lg.With("rtt", rtt).Info("nats server connection is healthy")
+			break
+		}
+		select {
+		case <-ctrl.Done():
+			return nil, ctx.Err()
+		case <-ctrl.Next():
+		}
+	}
+
+	js, err := nc.JetStream(nats.Context(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return &LockManager{
+		js:  js,
+		ctx: ctx,
+	}, nil
+}
+
+var _ storage.LockManager = (*LockManager)(nil)
+
+func (l *LockManager) Locker(key string, opts ...lock.LockOption) storage.Lock {
+	options := lock.DefaultLockOptions(l.ctx)
+	options.Apply(opts...)
+	return NewLock(l.js, key, options)
+}

--- a/pkg/test/benchmark/storage/storage_suite_test.go
+++ b/pkg/test/benchmark/storage/storage_suite_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher/opni/pkg/storage/etcd"
+	"github.com/rancher/opni/pkg/storage/jetstream"
 	"github.com/rancher/opni/pkg/test"
 	_ "github.com/rancher/opni/pkg/test/setup"
 	"github.com/rancher/opni/pkg/test/testruntime"
@@ -19,6 +20,7 @@ func TestStorage(t *testing.T) {
 }
 
 var lmsEtcdF = future.New[[]*etcd.EtcdLockManager]()
+var lmsJetstreamF = future.New[[]*jetstream.LockManager]()
 
 var _ = BeforeSuite(func() {
 	testruntime.IfIntegration(func() {
@@ -37,11 +39,18 @@ var _ = BeforeSuite(func() {
 			Expect(err).NotTo(HaveOccurred())
 			lmsE[i] = l
 		}
+		lmsJ := make([]*jetstream.LockManager, 7)
+		for i := 0; i < 7; i++ {
+			j, err := jetstream.NewJetstreamLockManager(context.Background(), env.JetStreamConfig())
+			Expect(err).NotTo(HaveOccurred())
+			lmsJ[i] = j
+		}
 
 		lmsEtcdF.Set(lmsE)
-		// lmsJetstreamF.Set(lmsJ)
+		lmsJetstreamF.Set(lmsJ)
 		DeferCleanup(env.Stop, "Test Suite Finished")
 	})
 })
 
 var _ = Describe("Etcd lock manager", Ordered, Serial, Label("integration", "slow"), LockManagerBenchmark("etcd", lmsEtcdF))
+var _ = Describe("Jetstream lock manager", Ordered, Serial, Label("integration", "slow"), LockManagerBenchmark("jetstream", lmsJetstreamF))

--- a/pkg/test/conformance/storage/lock_manager.go
+++ b/pkg/test/conformance/storage/lock_manager.go
@@ -84,7 +84,7 @@ func LockManagerTestSuite[T storage.LockManager](
 			})
 
 			Specify("locks should be able to acquire the lock if the existing lock has expired", func() {
-				exLock := lm.Locker("bar", lock.WithRetryDelay(1*time.Millisecond), lock.WithExpireDuration(0*time.Second))
+				exLock := lm.Locker("bar", lock.WithRetryDelay(1*time.Millisecond), lock.WithKeepalive(false), lock.WithExpireDuration(1*time.Second))
 				// some implementations expire durations are forced to round up to the largest second, so 3 *time.Second is a requirement here
 				otherLock := lm.Locker("bar", lock.WithAcquireTimeout(3*time.Second))
 				err := exLock.Lock()


### PR DESCRIPTION
An exclusive distributed lock implementation with the same liveliness guarantees as the etcd lock. 

Requires nats 2.9+