### PR TITLE
Update agent probes

### DIFF
--- a/packages/opni-agent/opni-agent/charts/templates/deployment.yaml
+++ b/packages/opni-agent/opni-agent/charts/templates/deployment.yaml
@@ -71,15 +71,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-              scheme: HTTP
-            timeoutSeconds: 1
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
           startupProbe:
             httpGet:
               path: /healthz
@@ -88,7 +79,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 10
+            failureThreshold: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: client


### PR DESCRIPTION
Fixes #1724

Have removed readiness check as it is redundant with the liveness check.  Behaviour with this PR is as follows:
 * On startup agent will wait for up to 5 minutes to become live.  This will give it time to download plugins on a slow network connection
 * After startup the container will restart if it becomes unavailable for 30 seconds.