### PR TITLE
Changing the default values when creating an Alerting Webhook endpoint

### DIFF
--- a/web/pkg/opni/components/Endpoint/Webhook.vue
+++ b/web/pkg/opni/components/Endpoint/Webhook.vue
@@ -36,17 +36,10 @@ export default {
     ];
 
     if (!this.value.httpConfig) {
-      this.$set(this.value, 'httpConfig', {
-        ...{ tlsConfig: {} },
-        ...(this.value.httpConfig || {})
-      });
+      this.$set(this.value, 'httpConfig', { ...(this.value.httpConfig || {}) });
     }
 
     const authorizationType = this.getAuthType(this.value.httpConfig);
-
-    if (this.$route.name === 'endpoint-create') {
-      this.setAuthDefault(authorizationType, authorizationTypes);
-    }
 
     return {
       authorizationTypes,


### PR DESCRIPTION
No longer have TLS or Authorization enabled by default

![image](https://github.com/rancher/opni/assets/55104481/8cabe807-ea15-40e2-8a03-03eccd7092c3)
