### PR TITLE
Logs fixes

### DIFF
--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -108,12 +108,10 @@ func (ws *Server) ListenAndServe(ctx waitctx.RestrictiveContext) error {
 	lg.With(
 		"address", listener.Addr(),
 	).Info("ui server starting")
-	// proxyTracer := otel.Tracer("dashboard-proxy")
 	webFsTracer := otel.Tracer("webfs")
 	router := gin.New()
 	router.Use(
 		gin.Recovery(),
-		gin.Logger(),
 		logger.GinLogger(ws.logger),
 		otelgin.Middleware("opni-ui"),
 	)
@@ -152,64 +150,7 @@ func (ws *Server) ListenAndServe(ctx waitctx.RestrictiveContext) error {
 		).Panic("failed to parse management API URL")
 		return err
 	}
-
 	router.Any("/opni-api/*any", gin.WrapH(http.StripPrefix("/opni-api", httputil.NewSingleHostReverseProxy(mgmtUrl))))
-	// router.Any("/opni-api/*any", gin.WrapH(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-	// 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-	// 	_, span := proxyTracer.Start(
-	// 		ctx,
-	// 		r.URL.Path,
-	// 		func() (tr []trace.SpanStartOption) {
-	// 			for k, v := range r.Header {
-	// 				tr = append(tr, trace.WithAttributes(attribute.String(k, strings.Join(v, ","))))
-
-	// 			}
-	// 			tr = append(tr, trace.WithAttributes(attribute.String("proxy-method", r.Method)))
-	// 			tr = append(tr, trace.WithAttributes(attribute.String("proxy-url", mgmtUrl.String())))
-	// 			return tr
-	// 		}()...,
-	// 	)
-
-	// 	defer func() {
-	// 		cancel()
-	// 		span.End()
-	// 	}()
-
-	// 	// round-trip to the management API
-	// 	// strip the prefix /opni-api/
-	// 	u := *mgmtUrl
-	// 	u.Path = r.URL.Path[len("/opni-api/"):]
-
-	// 	req, err := http.NewRequestWithContext(ctx, r.Method, u.String(), r.Body)
-	// 	if err != nil {
-	// 		lg.With(
-	// 			zap.Error(err),
-	// 		).Error("failed to create request")
-	// 		rw.WriteHeader(http.StatusInternalServerError)
-	// 		return
-	// 	}
-	// 	req.Header = r.Header
-	// 	resp, err := http.DefaultClient.Do(req)
-	// 	if err != nil {
-	// 		lg.With(
-	// 			zap.Error(err),
-	// 		).Error("failed to round-trip management api request")
-	// 		if errors.Is(err, ctx.Err()) {
-	// 			rw.WriteHeader(http.StatusGatewayTimeout)
-	// 			return
-	// 		}
-	// 		rw.WriteHeader(http.StatusInternalServerError)
-	// 		return
-	// 	}
-	// 	defer resp.Body.Close()
-	// 	for k, v := range resp.Header {
-	// 		for _, vv := range v {
-	// 			rw.Header().Add(k, vv)
-	// 		}
-	// 	}
-	// 	rw.WriteHeader(resp.StatusCode)
-	// 	io.Copy(rw, resp.Body)
-	// })))
 
 	for _, h := range ws.extraHandlers {
 		router.Handle(h.method, h.prefix, h.handler...)

--- a/plugins/alerting/pkg/alerting/alarms/v1/setup.go
+++ b/plugins/alerting/pkg/alerting/alarms/v1/setup.go
@@ -219,7 +219,7 @@ func (p *AlarmServerComponent) handleKubeAlertCreation(ctx context.Context, cond
 		cond.GetRoutingAnnotations(),
 		k, nil, baseKubeRule,
 	)
-	p.logger.With("handler", "kubeStateAlertCreate").Debugf("kube state alert created %v", kubeRuleContent)
+	// p.logger.With("handler", "kubeStateAlertCreate").Debugf("kube state alert created %v", kubeRuleContent)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func (p *AlarmServerComponent) handleKubeAlertCreation(ctx context.Context, cond
 	if err != nil {
 		return err
 	}
-	p.logger.With("Expr", "kube-state").Debugf("%s", string(out))
+	// p.logger.With("Expr", "kube-state").Debugf("%s", string(out))
 	adminClient, err := p.adminClient.GetContext(ctx)
 	if err != nil {
 		return err
@@ -272,7 +272,6 @@ func (p *AlarmServerComponent) handleCpuSaturationAlertCreation(
 	if err != nil {
 		return err
 	}
-	p.logger.With("Expr", "cpu").Debugf("%s", string(out))
 	adminClient, err := p.adminClient.GetContext(ctx)
 	if err != nil {
 		return err
@@ -314,7 +313,6 @@ func (p *AlarmServerComponent) handleMemorySaturationAlertCreation(ctx context.C
 	if err != nil {
 		return err
 	}
-	p.logger.With("Expr", "mem").Debugf("%s", string(out))
 	adminClient, err := p.adminClient.GetContext(ctx)
 	if err != nil {
 		return err
@@ -356,7 +354,6 @@ func (p *AlarmServerComponent) handleFsSaturationAlertCreation(ctx context.Conte
 	if err != nil {
 		return err
 	}
-	p.logger.With("Expr", "fs").Debugf("%s", string(out))
 	adminClient, err := p.adminClient.GetContext(ctx)
 	if err != nil {
 		return err
@@ -393,7 +390,6 @@ func (p *AlarmServerComponent) handlePrometheusQueryAlertCreation(ctx context.Co
 	if err != nil {
 		return err
 	}
-	p.logger.With("Expr", "user-query").Debugf("%s", out.String())
 	adminClient, err := p.adminClient.GetContext(ctx)
 	if err != nil {
 		return err

--- a/plugins/logging/pkg/backend/metadata.go
+++ b/plugins/logging/pkg/backend/metadata.go
@@ -10,7 +10,15 @@ import (
 )
 
 func (b *LoggingBackend) updateClusterMetadata(ctx context.Context, event *managementv1.WatchEvent) error {
-	newName, oldName := event.Cluster.Metadata.Labels[opnicorev1.NameLabel], event.Previous.Metadata.Labels[opnicorev1.NameLabel]
+	incomingLabels := event.GetCluster().GetMetadata().GetLabels()
+	previousLabels := event.GetPrevious().GetMetadata().GetLabels()
+	var newName, oldName string
+	if _, ok := incomingLabels[opnicorev1.NameLabel]; ok {
+		newName = incomingLabels[opnicorev1.NameLabel]
+	}
+	if _, ok := previousLabels[opnicorev1.NameLabel]; ok {
+		oldName = previousLabels[opnicorev1.NameLabel]
+	}
 	if newName == oldName {
 		b.Logger.With(
 			"oldName", oldName,
@@ -18,7 +26,6 @@ func (b *LoggingBackend) updateClusterMetadata(ctx context.Context, event *manag
 		).Debug("cluster was not renamed")
 		return nil
 	}
-
 	b.Logger.With(
 		"oldName", oldName,
 		"newName", newName,

--- a/web/pkg/opni/components/LoggingBackend/index.vue
+++ b/web/pkg/opni/components/LoggingBackend/index.vue
@@ -253,7 +253,7 @@ export default {
       </Tabbed>
     </template>
     <template #details>
-      <CapabilityTable name="logging" />
+      <CapabilityTable name="logs" />
     </template>
   </Backend>
 </template>


### PR DESCRIPTION
Cortex config introduced a couple of bugs related to logging:
- [X] Fixed  a bug in the logs capability table 
- [X] Updated cluster metadata to handle `nil` in some contexts. This is because management event update semantics have changed, notable `Create` and `Update` have been consolidated into `Put`; therefore we need to explicitly handle when some metadata may be `nil`.