### PR TITLE
cli gen: improve flag set defaults from message literals

### DIFF
--- a/plugins/metrics/apis/cortexops/cortexops_cli.pb.go
+++ b/plugins/metrics/apis/cortexops/cortexops_cli.pb.go
@@ -607,7 +607,7 @@ func (in *CortexApplicationConfig) FlagSet(prefix ...string) *pflag.FlagSet {
 	fs.AddFlagSet(in.Limits.FlagSet(append(prefix, "limits")...))
 	flagutil.SetDefValue(fs, strings.Join(append(prefix, "limits", "ingestion-rate"), "."), "600000")
 	flagutil.SetDefValue(fs, strings.Join(append(prefix, "limits", "ingestion-burst-size"), "."), "1000000")
-	flagutil.SetDefValue(fs, strings.Join(append(prefix, "limits", "compactor-blocks-retention-period"), "."), "seconds:2592000")
+	flagutil.SetDefValue(fs, strings.Join(append(prefix, "limits", "compactor-blocks-retention-period"), "."), "720h0m0s")
 	if in.RuntimeConfig == nil {
 		in.RuntimeConfig = &runtimeconfig.RuntimeConfigValues{}
 	}


### PR DESCRIPTION
This improves how field values from nested message literals are rendered as strings for flag set defaults.

---

For example, given:
```proto
message MetricsCapabilitySpec {
  .config.v1beta1.RulesSpec rules = 1 [(cli.flag_set).default = {
    [type.googleapis.com/config.v1beta1.RulesSpec]: {
      discovery: {
        prometheusRules: {
          searchNamespaces: [""]; // search all namespaces
        }
      }
    }
  }];
}
```

The default field above will translate into this call to flagutil.SetDefValue:
```go
func (in *MetricsCapabilitySpec) FlagSet(prefix ...string) *pflag.FlagSet {
	// ...

	fs.AddFlagSet(in.Rules.FlagSet(append(prefix, "rules")...))
	flagutil.SetDefValue(fs, strings.Join(append(prefix, "rules", "discovery.prometheus-rules.search-namespaces"), "."), `[""]`)

	// ...
}

```

Partial fix for https://github.com/rancher/opni/issues/1735