### PR TITLE
Cert & alerting fixes

### DIFF
--- a/plugins/alerting/pkg/alerting/alarms/v1/status.go
+++ b/plugins/alerting/pkg/alerting/alarms/v1/status.go
@@ -2,13 +2,13 @@ package alarms
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	promClient "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/rancher/opni/pkg/alerting/drivers/cortex"
 	"github.com/rancher/opni/pkg/alerting/drivers/routing"
 	"github.com/rancher/opni/pkg/alerting/shared"
 	alertingv1 "github.com/rancher/opni/pkg/apis/alerting/v1"
@@ -83,7 +83,7 @@ func (a *AlarmServerComponent) checkMetricsClusterStatus(
 			Reason: "cluster does not have metrics capabilities installed",
 		}
 	}
-	if status := evaluatePrometheusRuleHealth(metricsInfo.cortexRules, cond.GetId()); status != nil {
+	if status := a.evaluatePrometheusRuleHealth(cond, metricsInfo.cortexRules); status != nil {
 		return status
 	}
 	return &alertingv1.AlertStatusResponse{
@@ -372,44 +372,84 @@ func statusFromAlertGroup(
 	return defaultState
 }
 
-func evaluatePrometheusRuleHealth(ruleList *cortexadmin.RuleGroups, id string) *alertingv1.AlertStatusResponse {
+func (a *AlarmServerComponent) evaluatePrometheusRuleHealth(cond *alertingv1.AlertCondition, ruleList *cortexadmin.RuleGroups) *alertingv1.AlertStatusResponse {
 	if ruleList == nil {
 		return &alertingv1.AlertStatusResponse{
 			State:  alertingv1.AlertConditionState_Pending,
 			Reason: "waiting for monitoring rule state(s) to be available from metrics backend",
 		}
 	}
+	insufficientMetadata := &alertingv1.AlertStatusResponse{
+		State:  alertingv1.AlertConditionState_Pending,
+		Reason: "insufficient metadata required to reference remote rule",
+	}
+	md := cond.GetMetadata()
+	if md == nil {
+		return insufficientMetadata
+	}
+	groupName, ok := md[cortex.MetadataCortexGroup]
+	if !ok {
+		return insufficientMetadata
+	}
+
+	ruleName, ok := md[cortex.MetadataCortexRuleName]
+	if !ok {
+		return insufficientMetadata
+	}
 
 	for _, group := range ruleList.GetGroups() {
-		if strings.Contains(group.GetName(), id) {
-			if len(group.GetRules()) == 0 {
-				return &alertingv1.AlertStatusResponse{
-					State:  alertingv1.AlertConditionState_Pending,
-					Reason: "waiting for monitoring rule state(s) to be available from metrics backend",
-				}
+		if group.GetName() != groupName {
+			continue
+		}
+		if len(group.GetRules()) == 0 {
+			return &alertingv1.AlertStatusResponse{
+				State:  alertingv1.AlertConditionState_Pending,
+				Reason: "waiting for monitoring rule state(s) to be available from metrics backend",
 			}
-			healthList := lo.Map(group.GetRules(), func(rule *cortexadmin.Rule, _ int) string {
-				return rule.GetHealth()
-			})
-			health := lo.Associate(healthList, func(health string) (string, struct{}) {
-				return health, struct{}{}
-			})
-			if _, ok := health[promClient.RuleHealthBad]; ok {
-				return &alertingv1.AlertStatusResponse{
-					State:  alertingv1.AlertConditionState_Invalidated,
-					Reason: "one or more metric dependencies are unable to be evaluated",
-				}
+		}
+		found := false
+		for _, rule := range group.GetRules() {
+			if rule.GetName() == ruleName {
+				found = true
 			}
-			if _, ok := health[promClient.RuleHealthUnknown]; ok {
-				return &alertingv1.AlertStatusResponse{
-					State:  alertingv1.AlertConditionState_Pending,
-					Reason: "waiting for monitoring rule state(s) to be available from metrics backend",
-				}
+		}
+		if !found {
+			return &alertingv1.AlertStatusResponse{
+				State:  alertingv1.AlertConditionState_Pending,
+				Reason: "prometheus alerting rule is not found in metrics backend",
 			}
+		}
+
+		healthList := lo.Map(group.GetRules(), func(rule *cortexadmin.Rule, _ int) string {
+			return rule.GetHealth()
+		})
+		health := lo.Associate(healthList, func(health string) (string, struct{}) {
+			return health, struct{}{}
+		})
+		if _, ok := health[promClient.RuleHealthBad]; ok {
+			return &alertingv1.AlertStatusResponse{
+				State:  alertingv1.AlertConditionState_Invalidated,
+				Reason: "one or more prometheus rules in this group are unable to be evaluated",
+			}
+		}
+		if _, ok := health[promClient.RuleHealthUnknown]; ok {
+			return &alertingv1.AlertStatusResponse{
+				State:  alertingv1.AlertConditionState_Pending,
+				Reason: "waiting for all prometheus rule state(s) to be available from metrics backend",
+			}
+		}
+		return &alertingv1.AlertStatusResponse{
+			State: alertingv1.AlertConditionState_Ok,
+		}
+	}
+	if _, ok := md[metadataInactiveAlarm]; ok {
+		return &alertingv1.AlertStatusResponse{
+			State:  alertingv1.AlertConditionState_Pending,
+			Reason: "prometheus rule group has not been created yet",
 		}
 	}
 	return &alertingv1.AlertStatusResponse{
-		State:  alertingv1.AlertConditionState_Pending,
-		Reason: "prometheus rule is not found in metrics backend",
+		State:  alertingv1.AlertConditionState_Invalidated,
+		Reason: "prometheus rule group could not be found in metrics backend",
 	}
 }

--- a/plugins/alerting/pkg/alerting/alarms/v1/status.go
+++ b/plugins/alerting/pkg/alerting/alarms/v1/status.go
@@ -408,5 +408,8 @@ func evaluatePrometheusRuleHealth(ruleList *cortexadmin.RuleGroups, id string) *
 			}
 		}
 	}
-	return nil
+	return &alertingv1.AlertStatusResponse{
+		State:  alertingv1.AlertConditionState_Pending,
+		Reason: "prometheus rule is not found in metrics backend",
+	}
 }

--- a/plugins/alerting/pkg/alerting/drivers/alerting_manager/alerting_manager_suite_test.go
+++ b/plugins/alerting/pkg/alerting/drivers/alerting_manager/alerting_manager_suite_test.go
@@ -1,0 +1,15 @@
+package alerting_manager_test
+
+import (
+	"testing"
+
+	_ "github.com/rancher/opni/pkg/test/setup"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAlertingManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AlertingManager Suite")
+}

--- a/plugins/alerting/pkg/alerting/drivers/alerting_manager/cluster_driver.go
+++ b/plugins/alerting/pkg/alerting/drivers/alerting_manager/cluster_driver.go
@@ -133,6 +133,7 @@ func (a *AlertingClusterManager) InstallCluster(ctx context.Context, _ *emptypb.
 		lg.Error(fmt.Sprintf("%s", retryErr))
 		return nil, retryErr
 	}
+	a.notify(1)
 	return &emptypb.Empty{}, nil
 }
 
@@ -343,6 +344,7 @@ func (a *AlertingClusterManager) notify(replicas int) {
 		alertingClient.WithQuerierAddress(
 			fmt.Sprintf("%s:3000", shared.AlertmanagerService),
 		),
+		alertingClient.WithTLSConfig(a.TlsConfig),
 	)
 	if err != nil {
 		panic(err)

--- a/plugins/alerting/pkg/alerting/drivers/alerting_manager/cluster_driver.go
+++ b/plugins/alerting/pkg/alerting/drivers/alerting_manager/cluster_driver.go
@@ -366,8 +366,8 @@ func listPeers(replicas int) []alertingClient.AlertingPeer {
 	peers := []alertingClient.AlertingPeer{}
 	for i := 0; i < replicas; i++ {
 		peers = append(peers, alertingClient.AlertingPeer{
-			ApiAddress:      fmt.Sprintf("http://%s-%d.%s:9093", shared.AlertmanagerService, i, shared.AlertmanagerService),
-			EmbeddedAddress: fmt.Sprintf("http://%s-%d.%s:3000", shared.AlertmanagerService, i, shared.AlertmanagerService),
+			ApiAddress:      fmt.Sprintf("%s-%d.%s:9093", shared.AlertmanagerService, i, shared.AlertmanagerService),
+			EmbeddedAddress: fmt.Sprintf("%s-%d.%s:3000", shared.AlertmanagerService, i, shared.AlertmanagerService),
 		})
 	}
 	return peers

--- a/plugins/alerting/pkg/alerting/drivers/alerting_manager/driver_test.go
+++ b/plugins/alerting/pkg/alerting/drivers/alerting_manager/driver_test.go
@@ -1,0 +1,48 @@
+package alerting_manager_test
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/opni/pkg/alerting/client"
+	"github.com/rancher/opni/pkg/alerting/shared"
+	"github.com/rancher/opni/pkg/logger"
+	"github.com/rancher/opni/pkg/plugins/driverutil"
+	"github.com/rancher/opni/plugins/alerting/pkg/alerting/drivers/alerting_manager"
+)
+
+var _ = Describe("", Label("unit"), func() {
+	When("We register the alering cluster driver", func() {
+		It("should apply the tls config via driver options", func() {
+			tlsConfig := &tls.Config{}
+			opts := []driverutil.Option{
+				driverutil.NewOption("tlsConfig", tlsConfig),
+			}
+
+			options := alerting_manager.AlertingDriverOptions{
+				ConfigKey:          shared.AlertManagerConfigKey,
+				InternalRoutingKey: shared.InternalRoutingConfigKey,
+				Logger:             logger.NewPluginLogger().WithGroup("alerting").WithGroup("alerting-manager"),
+			}
+			driverutil.ApplyOptions(&options, opts...)
+			Expect(options.TlsConfig).NotTo(BeNil())
+		})
+
+		It("should apply cluster driver subscribers via driver options", func() {
+			subscriberA := make(chan client.AlertingClient)
+			subscriberB := make(chan client.AlertingClient)
+			opts := []driverutil.Option{
+				driverutil.NewOption("subscribers", []chan client.AlertingClient{subscriberA, subscriberB}),
+			}
+
+			options := alerting_manager.AlertingDriverOptions{
+				ConfigKey:          shared.AlertManagerConfigKey,
+				InternalRoutingKey: shared.InternalRoutingConfigKey,
+				Logger:             logger.NewPluginLogger().WithGroup("alerting").WithGroup("alerting-manager"),
+			}
+			driverutil.ApplyOptions(&options, opts...)
+			Expect(options.Subscribers).To(HaveLen(2))
+		})
+	})
+})

--- a/plugins/alerting/pkg/alerting/drivers/alerting_manager/options.go
+++ b/plugins/alerting/pkg/alerting/drivers/alerting_manager/options.go
@@ -1,10 +1,12 @@
 package alerting_manager
 
 import (
+	"crypto/tls"
+	"log/slog"
+
 	alertingClient "github.com/rancher/opni/pkg/alerting/client"
 	"github.com/rancher/opni/pkg/alerting/shared"
 	"k8s.io/apimachinery/pkg/types"
-	"log/slog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,4 +18,5 @@ type AlertingDriverOptions struct {
 	InternalRoutingKey string                               `option:"internalRoutingKey"`
 	AlertingOptions    *shared.AlertingClusterOptions       `option:"alertingOptions"`
 	Subscribers        []chan alertingClient.AlertingClient `option:"subscribers"`
+	TlsConfig          *tls.Config                          `option:"tlsConfig"`
 }

--- a/web/pkg/opni/models/alerting/Condition.ts
+++ b/web/pkg/opni/models/alerting/Condition.ts
@@ -494,7 +494,7 @@ export class Condition extends Resource {
   }
 
   async remove() {
-    await deleteAlertCondition(this.id);
+    await deleteAlertCondition(this.id, this.groupId);
     super.remove();
   }
 

--- a/web/pkg/opni/utils/requests/alerts.ts
+++ b/web/pkg/opni/utils/requests/alerts.ts
@@ -4,9 +4,7 @@ import { Reference } from '../../models/shared';
 import {
   AlertCondition, AlertConditionList, AlertDetailChoicesRequest, AlertStatusResponse, Condition, ConditionReference, ListAlarmMessageRequest, ListAlertTypeDetails, ListMessageResponse, ListStatusResponse, SilenceRequest, TimelineRequest, TimelineResponse, UpdateAlertConditionRequest
 } from '../../models/alerting/Condition';
-import {
-  AlertEndpoint, AlertEndpointList, Endpoint, UpdateAlertEndpointRequest
-} from '../../models/alerting/Endpoint';
+import { AlertEndpoint, AlertEndpointList, Endpoint, UpdateAlertEndpointRequest } from '../../models/alerting/Endpoint';
 import { Cluster } from '../../models/Cluster';
 
 export async function createAlertEndpoint(endpoint: AlertEndpoint) {
@@ -68,8 +66,8 @@ export async function getAlertConditionChoices(request: AlertDetailChoicesReques
   return (await axios.post<ListAlertTypeDetails>('opni-api/AlertConditions/choices', request)).data;
 }
 
-export function deleteAlertCondition(id: string) {
-  return axios.delete(`opni-api/AlertConditions/configure`, { data: { id } });
+export function deleteAlertCondition(id: string, groupId : string) {
+  return axios.delete(`opni-api/AlertConditions/configure`, { data: { id, groupId } });
 }
 
 export async function getAlertConditionStatus(id: string): Promise<AlertStatusResponse> {


### PR DESCRIPTION
- Fixed a change lost in one of the rebases; cluster drivers are only responsible for finding the alerting cluster peers, not initializing clients
- Fixed a bug where an initial install of the alerting cluster would always result in a TLS error
- Fixed a missing edge case where prometheus rules not being present in the metrics backend resulted in an `Ok` status instead of `Pending`
- Fixed a UI bug that made it impossible to delete alert conditions
- Improved the detection of the existence of rule objects in cortex from the alerting plugin