### PR TITLE
Update service generation so we can surface some sort of status error

### DIFF
--- a/web/pkg/opni/generated/github.com/rancher/opni/pkg/apis/capability/v1/capability_pb.ts
+++ b/web/pkg/opni/generated/github.com/rancher/opni/pkg/apis/capability/v1/capability_pb.ts
@@ -4,7 +4,7 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto3, Struct, Timestamp } from "@bufbuild/protobuf";
-import { Reference } from "../../core/v1/core_pb";
+import { Reference, Revision } from "../../core/v1/core_pb";
 
 /**
  * @generated from enum capability.InstallResponseStatus
@@ -354,6 +354,11 @@ export class NodeCapabilityStatus extends Message<NodeCapabilityStatus> {
    */
   conditions: string[] = [];
 
+  /**
+   * @generated from field: core.Revision lastRevision = 4;
+   */
+  lastRevision?: Revision;
+
   constructor(data?: PartialMessage<NodeCapabilityStatus>) {
     super();
     proto3.util.initPartial(data, this);
@@ -365,6 +370,7 @@ export class NodeCapabilityStatus extends Message<NodeCapabilityStatus> {
     { no: 1, name: "enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 2, name: "lastSync", kind: "message", T: Timestamp },
     { no: 3, name: "conditions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 4, name: "lastRevision", kind: "message", T: Revision },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NodeCapabilityStatus {

--- a/web/pkg/opni/generated/github.com/rancher/opni/pkg/apis/management/v1/management_svc.ts
+++ b/web/pkg/opni/generated/github.com/rancher/opni/pkg/apis/management/v1/management_svc.ts
@@ -18,8 +18,7 @@ export async function CreateBootstrapToken(input: CreateBootstrapTokenRequest): 
       console.info('Here is the input for a request to Management-CreateBootstrapToken:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => BootstrapToken.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -30,8 +29,9 @@ export async function CreateBootstrapToken(input: CreateBootstrapTokenRequest): 
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = BootstrapToken.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-CreateBootstrapToken:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -49,7 +49,7 @@ export async function RevokeBootstrapToken(input: Reference): Promise<void> {
       console.info('Here is the input for a request to Management-RevokeBootstrapToken:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -60,8 +60,9 @@ export async function RevokeBootstrapToken(input: Reference): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-RevokeBootstrapToken:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -75,8 +76,7 @@ export async function RevokeBootstrapToken(input: Reference): Promise<void> {
 export async function ListBootstrapTokens(): Promise<BootstrapTokenList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => BootstrapTokenList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -86,8 +86,9 @@ export async function ListBootstrapTokens(): Promise<BootstrapTokenList> {
       url: `/opni-api/Management/tokens`
     })).data;
 
+    const response = BootstrapTokenList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-ListBootstrapTokens:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -105,8 +106,7 @@ export async function GetBootstrapToken(input: Reference): Promise<BootstrapToke
       console.info('Here is the input for a request to Management-GetBootstrapToken:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => BootstrapToken.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -117,8 +117,9 @@ export async function GetBootstrapToken(input: Reference): Promise<BootstrapToke
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = BootstrapToken.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetBootstrapToken:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -136,8 +137,7 @@ export async function ListClusters(input: ListClustersRequest): Promise<ClusterL
       console.info('Here is the input for a request to Management-ListClusters:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => ClusterList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -148,8 +148,9 @@ export async function ListClusters(input: ListClustersRequest): Promise<ClusterL
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = ClusterList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-ListClusters:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -195,7 +196,7 @@ export async function DeleteCluster(input: Reference): Promise<void> {
       console.info('Here is the input for a request to Management-DeleteCluster:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -206,8 +207,9 @@ export async function DeleteCluster(input: Reference): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-DeleteCluster:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -221,8 +223,7 @@ export async function DeleteCluster(input: Reference): Promise<void> {
 export async function CertsInfo(): Promise<CertsInfoResponse> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => CertsInfoResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -232,8 +233,9 @@ export async function CertsInfo(): Promise<CertsInfoResponse> {
       url: `/opni-api/Management/certs`
     })).data;
 
+    const response = CertsInfoResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-CertsInfo:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -251,8 +253,7 @@ export async function GetCluster(input: Reference): Promise<Cluster> {
       console.info('Here is the input for a request to Management-GetCluster:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => Cluster.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -263,8 +264,9 @@ export async function GetCluster(input: Reference): Promise<Cluster> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = Cluster.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetCluster:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -282,8 +284,7 @@ export async function GetClusterHealthStatus(input: Reference): Promise<HealthSt
       console.info('Here is the input for a request to Management-GetClusterHealthStatus:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => HealthStatus.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -294,8 +295,9 @@ export async function GetClusterHealthStatus(input: Reference): Promise<HealthSt
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = HealthStatus.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetClusterHealthStatus:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -341,8 +343,7 @@ export async function EditCluster(input: EditClusterRequest): Promise<Cluster> {
       console.info('Here is the input for a request to Management-EditCluster:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => Cluster.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -353,8 +354,9 @@ export async function EditCluster(input: EditClusterRequest): Promise<Cluster> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = Cluster.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-EditCluster:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -372,7 +374,7 @@ export async function CreateRole(input: Role): Promise<void> {
       console.info('Here is the input for a request to Management-CreateRole:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -383,8 +385,9 @@ export async function CreateRole(input: Role): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-CreateRole:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -402,7 +405,7 @@ export async function UpdateRole(input: Role): Promise<void> {
       console.info('Here is the input for a request to Management-UpdateRole:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -413,8 +416,9 @@ export async function UpdateRole(input: Role): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-UpdateRole:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -432,7 +436,7 @@ export async function DeleteRole(input: Reference): Promise<void> {
       console.info('Here is the input for a request to Management-DeleteRole:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -443,8 +447,9 @@ export async function DeleteRole(input: Reference): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-DeleteRole:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -462,8 +467,7 @@ export async function GetRole(input: Reference): Promise<Role> {
       console.info('Here is the input for a request to Management-GetRole:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => Role.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -474,8 +478,9 @@ export async function GetRole(input: Reference): Promise<Role> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = Role.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetRole:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -493,7 +498,7 @@ export async function CreateRoleBinding(input: RoleBinding): Promise<void> {
       console.info('Here is the input for a request to Management-CreateRoleBinding:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -504,8 +509,9 @@ export async function CreateRoleBinding(input: RoleBinding): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-CreateRoleBinding:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -523,7 +529,7 @@ export async function UpdateRoleBinding(input: RoleBinding): Promise<void> {
       console.info('Here is the input for a request to Management-UpdateRoleBinding:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -534,8 +540,9 @@ export async function UpdateRoleBinding(input: RoleBinding): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-UpdateRoleBinding:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -553,7 +560,7 @@ export async function DeleteRoleBinding(input: Reference): Promise<void> {
       console.info('Here is the input for a request to Management-DeleteRoleBinding:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -564,8 +571,9 @@ export async function DeleteRoleBinding(input: Reference): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-DeleteRoleBinding:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -583,8 +591,7 @@ export async function GetRoleBinding(input: Reference): Promise<RoleBinding> {
       console.info('Here is the input for a request to Management-GetRoleBinding:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => RoleBinding.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -595,8 +602,9 @@ export async function GetRoleBinding(input: Reference): Promise<RoleBinding> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = RoleBinding.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetRoleBinding:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -610,8 +618,7 @@ export async function GetRoleBinding(input: Reference): Promise<RoleBinding> {
 export async function ListRoles(): Promise<RoleList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => RoleList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -621,8 +628,9 @@ export async function ListRoles(): Promise<RoleList> {
       url: `/opni-api/Management/roles`
     })).data;
 
+    const response = RoleList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-ListRoles:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -636,8 +644,7 @@ export async function ListRoles(): Promise<RoleList> {
 export async function ListRoleBindings(): Promise<RoleBindingList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => RoleBindingList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -647,8 +654,9 @@ export async function ListRoleBindings(): Promise<RoleBindingList> {
       url: `/opni-api/Management/rolebindings`
     })).data;
 
+    const response = RoleBindingList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-ListRoleBindings:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -666,8 +674,7 @@ export async function SubjectAccess(input: SubjectAccessRequest): Promise<Refere
       console.info('Here is the input for a request to Management-SubjectAccess:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => ReferenceList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -678,8 +685,9 @@ export async function SubjectAccess(input: SubjectAccessRequest): Promise<Refere
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = ReferenceList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-SubjectAccess:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -693,8 +701,7 @@ export async function SubjectAccess(input: SubjectAccessRequest): Promise<Refere
 export async function APIExtensions(): Promise<APIExtensionInfoList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => APIExtensionInfoList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -704,8 +711,9 @@ export async function APIExtensions(): Promise<APIExtensionInfoList> {
       url: `/opni-api/Management/apiextensions`
     })).data;
 
+    const response = APIExtensionInfoList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-APIExtensions:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -719,8 +727,7 @@ export async function APIExtensions(): Promise<APIExtensionInfoList> {
 export async function GetConfig(): Promise<GatewayConfig> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => GatewayConfig.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -730,8 +737,9 @@ export async function GetConfig(): Promise<GatewayConfig> {
       url: `/opni-api/Management/config`
     })).data;
 
+    const response = GatewayConfig.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetConfig:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -749,7 +757,7 @@ export async function UpdateConfig(input: UpdateConfigRequest): Promise<void> {
       console.info('Here is the input for a request to Management-UpdateConfig:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -760,8 +768,9 @@ export async function UpdateConfig(input: UpdateConfigRequest): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-UpdateConfig:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -775,8 +784,7 @@ export async function UpdateConfig(input: UpdateConfigRequest): Promise<void> {
 export async function ListCapabilities(): Promise<CapabilityList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => CapabilityList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -786,8 +794,9 @@ export async function ListCapabilities(): Promise<CapabilityList> {
       url: `/opni-api/Management/capabilities`
     })).data;
 
+    const response = CapabilityList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-ListCapabilities:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -805,8 +814,7 @@ export async function CapabilityInstaller(input: CapabilityInstallerRequest): Pr
       console.info('Here is the input for a request to Management-CapabilityInstaller:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => CapabilityInstallerResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -817,8 +825,9 @@ export async function CapabilityInstaller(input: CapabilityInstallerRequest): Pr
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = CapabilityInstallerResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-CapabilityInstaller:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -836,8 +845,7 @@ export async function InstallCapability(input: CapabilityInstallRequest): Promis
       console.info('Here is the input for a request to Management-InstallCapability:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => InstallResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -848,8 +856,9 @@ export async function InstallCapability(input: CapabilityInstallRequest): Promis
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = InstallResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-InstallCapability:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -867,7 +876,7 @@ export async function UninstallCapability(input: CapabilityUninstallRequest): Pr
       console.info('Here is the input for a request to Management-UninstallCapability:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -878,8 +887,9 @@ export async function UninstallCapability(input: CapabilityUninstallRequest): Pr
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-UninstallCapability:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -897,8 +907,7 @@ export async function CapabilityStatus(input: CapabilityStatusRequest): Promise<
       console.info('Here is the input for a request to Management-CapabilityStatus:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => NodeCapabilityStatus.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -909,8 +918,9 @@ export async function CapabilityStatus(input: CapabilityStatusRequest): Promise<
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = NodeCapabilityStatus.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-CapabilityStatus:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -928,8 +938,7 @@ export async function CapabilityUninstallStatus(input: CapabilityStatusRequest):
       console.info('Here is the input for a request to Management-CapabilityUninstallStatus:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => TaskStatus.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -940,8 +949,9 @@ export async function CapabilityUninstallStatus(input: CapabilityStatusRequest):
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = TaskStatus.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-CapabilityUninstallStatus:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -959,7 +969,7 @@ export async function CancelCapabilityUninstall(input: CapabilityUninstallCancel
       console.info('Here is the input for a request to Management-CancelCapabilityUninstall:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -970,8 +980,9 @@ export async function CancelCapabilityUninstall(input: CapabilityUninstallCancel
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-CancelCapabilityUninstall:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -985,8 +996,7 @@ export async function CancelCapabilityUninstall(input: CapabilityUninstallCancel
 export async function GetDashboardSettings(): Promise<DashboardSettings> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => DashboardSettings.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -996,8 +1006,9 @@ export async function GetDashboardSettings(): Promise<DashboardSettings> {
       url: `/opni-api/Management/dashboard/settings`
     })).data;
 
+    const response = DashboardSettings.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to Management-GetDashboardSettings:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -1015,7 +1026,7 @@ export async function UpdateDashboardSettings(input: DashboardSettings): Promise
       console.info('Here is the input for a request to Management-UpdateDashboardSettings:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -1026,8 +1037,9 @@ export async function UpdateDashboardSettings(input: DashboardSettings): Promise
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to Management-UpdateDashboardSettings:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));

--- a/web/pkg/opni/generated/github.com/rancher/opni/plugins/logging/apis/loggingadmin/loggingadmin_svc.ts
+++ b/web/pkg/opni/generated/github.com/rancher/opni/plugins/logging/apis/loggingadmin/loggingadmin_svc.ts
@@ -10,8 +10,7 @@ import { SnapshotStatusList } from "@pkg/opni/models/LoggingAdminV2/SnapshotStat
 export async function GetOpensearchCluster(): Promise<OpensearchClusterV2> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => OpensearchClusterV2.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -21,8 +20,9 @@ export async function GetOpensearchCluster(): Promise<OpensearchClusterV2> {
       url: `/opni-api/LoggingAdminV2/logging/cluster`
     })).data;
 
+    const response = OpensearchClusterV2.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to LoggingAdminV2-GetOpensearchCluster:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -36,7 +36,7 @@ export async function GetOpensearchCluster(): Promise<OpensearchClusterV2> {
 export async function DeleteOpensearchCluster(): Promise<void> {
   try {
     
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -46,8 +46,9 @@ export async function DeleteOpensearchCluster(): Promise<void> {
       url: `/opni-api/LoggingAdminV2/logging/cluster`
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to LoggingAdminV2-DeleteOpensearchCluster:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -65,7 +66,7 @@ export async function CreateOrUpdateOpensearchCluster(input: OpensearchClusterV2
       console.info('Here is the input for a request to LoggingAdminV2-CreateOrUpdateOpensearchCluster:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -76,8 +77,9 @@ export async function CreateOrUpdateOpensearchCluster(input: OpensearchClusterV2
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to LoggingAdminV2-CreateOrUpdateOpensearchCluster:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -91,8 +93,7 @@ export async function CreateOrUpdateOpensearchCluster(input: OpensearchClusterV2
 export async function UpgradeAvailable(): Promise<UpgradeAvailableResponse> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => UpgradeAvailableResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -102,8 +103,9 @@ export async function UpgradeAvailable(): Promise<UpgradeAvailableResponse> {
       url: `/opni-api/LoggingAdminV2/logging/upgrade/available`
     })).data;
 
+    const response = UpgradeAvailableResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to LoggingAdminV2-UpgradeAvailable:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -121,7 +123,7 @@ export async function DoUpgrade(input: UpgradeOptions): Promise<void> {
       console.info('Here is the input for a request to LoggingAdminV2-DoUpgrade:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -132,8 +134,9 @@ export async function DoUpgrade(input: UpgradeOptions): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to LoggingAdminV2-DoUpgrade:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -147,8 +150,7 @@ export async function DoUpgrade(input: UpgradeOptions): Promise<void> {
 export async function GetStorageClasses(): Promise<StorageClassResponse> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => StorageClassResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -158,8 +160,9 @@ export async function GetStorageClasses(): Promise<StorageClassResponse> {
       url: `/opni-api/LoggingAdminV2/logging/storageclasses`
     })).data;
 
+    const response = StorageClassResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to LoggingAdminV2-GetStorageClasses:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -173,8 +176,7 @@ export async function GetStorageClasses(): Promise<StorageClassResponse> {
 export async function GetOpensearchStatus(): Promise<StatusResponse> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => StatusResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -184,8 +186,9 @@ export async function GetOpensearchStatus(): Promise<StatusResponse> {
       url: `/opni-api/LoggingAdminV2/logging/status`
     })).data;
 
+    const response = StatusResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to LoggingAdminV2-GetOpensearchStatus:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -203,7 +206,7 @@ export async function CreateOrUpdateSnapshotSchedule(input: SnapshotSchedule): P
       console.info('Here is the input for a request to LoggingAdminV2-CreateOrUpdateSnapshotSchedule:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -214,8 +217,9 @@ export async function CreateOrUpdateSnapshotSchedule(input: SnapshotSchedule): P
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to LoggingAdminV2-CreateOrUpdateSnapshotSchedule:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -233,8 +237,7 @@ export async function GetSnapshotSchedule(input: SnapshotReference): Promise<Sna
       console.info('Here is the input for a request to LoggingAdminV2-GetSnapshotSchedule:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => SnapshotSchedule.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -245,8 +248,9 @@ export async function GetSnapshotSchedule(input: SnapshotReference): Promise<Sna
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = SnapshotSchedule.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to LoggingAdminV2-GetSnapshotSchedule:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -264,7 +268,7 @@ export async function DeleteSnapshotSchedule(input: SnapshotReference): Promise<
       console.info('Here is the input for a request to LoggingAdminV2-DeleteSnapshotSchedule:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -275,8 +279,9 @@ export async function DeleteSnapshotSchedule(input: SnapshotReference): Promise<
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to LoggingAdminV2-DeleteSnapshotSchedule:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -290,8 +295,7 @@ export async function DeleteSnapshotSchedule(input: SnapshotReference): Promise<
 export async function ListSnapshotSchedules(): Promise<SnapshotStatusList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => SnapshotStatusList$1.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -301,8 +305,9 @@ export async function ListSnapshotSchedules(): Promise<SnapshotStatusList> {
       url: `/opni-api/LoggingAdminV2/logging/snapshot`
     })).data;
 
+    const response = SnapshotStatusList$1.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to LoggingAdminV2-ListSnapshotSchedules:', response);
-    return new SnapshotStatusList(response)
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));

--- a/web/pkg/opni/generated/github.com/rancher/opni/plugins/metrics/apis/cortexadmin/cortexadmin_svc.ts
+++ b/web/pkg/opni/generated/github.com/rancher/opni/plugins/metrics/apis/cortexadmin/cortexadmin_svc.ts
@@ -10,8 +10,7 @@ import { CortexStatus } from "./status_pb";
 export async function AllUserStats(): Promise<UserIDStatsList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => UserIDStatsList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -21,8 +20,9 @@ export async function AllUserStats(): Promise<UserIDStatsList> {
       url: `/opni-api/CortexAdmin/all_user_stats`
     })).data;
 
+    const response = UserIDStatsList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-AllUserStats:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -40,8 +40,7 @@ export async function WriteMetrics(input: WriteRequest): Promise<WriteResponse> 
       console.info('Here is the input for a request to CortexAdmin-WriteMetrics:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => WriteResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -52,8 +51,9 @@ export async function WriteMetrics(input: WriteRequest): Promise<WriteResponse> 
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = WriteResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-WriteMetrics:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -71,8 +71,7 @@ export async function Query(input: QueryRequest): Promise<QueryResponse> {
       console.info('Here is the input for a request to CortexAdmin-Query:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => QueryResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -83,8 +82,9 @@ export async function Query(input: QueryRequest): Promise<QueryResponse> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = QueryResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-Query:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -102,8 +102,7 @@ export async function QueryRange(input: QueryRangeRequest): Promise<QueryRespons
       console.info('Here is the input for a request to CortexAdmin-QueryRange:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => QueryResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -114,8 +113,9 @@ export async function QueryRange(input: QueryRangeRequest): Promise<QueryRespons
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = QueryResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-QueryRange:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -133,8 +133,7 @@ export async function GetRule(input: GetRuleRequest): Promise<QueryResponse> {
       console.info('Here is the input for a request to CortexAdmin-GetRule:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => QueryResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -145,8 +144,9 @@ export async function GetRule(input: GetRuleRequest): Promise<QueryResponse> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = QueryResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-GetRule:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -164,8 +164,7 @@ export async function GetMetricMetadata(input: MetricMetadataRequest): Promise<M
       console.info('Here is the input for a request to CortexAdmin-GetMetricMetadata:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => MetricMetadata.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -176,8 +175,9 @@ export async function GetMetricMetadata(input: MetricMetadataRequest): Promise<M
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = MetricMetadata.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-GetMetricMetadata:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -195,8 +195,7 @@ export async function ListRules(input: ListRulesRequest): Promise<ListRulesRespo
       console.info('Here is the input for a request to CortexAdmin-ListRules:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => ListRulesResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -207,8 +206,9 @@ export async function ListRules(input: ListRulesRequest): Promise<ListRulesRespo
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = ListRulesResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-ListRules:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -226,7 +226,7 @@ export async function LoadRules(input: LoadRuleRequest): Promise<void> {
       console.info('Here is the input for a request to CortexAdmin-LoadRules:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -237,8 +237,9 @@ export async function LoadRules(input: LoadRuleRequest): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexAdmin-LoadRules:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -256,7 +257,7 @@ export async function DeleteRule(input: DeleteRuleRequest): Promise<void> {
       console.info('Here is the input for a request to CortexAdmin-DeleteRule:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -267,8 +268,9 @@ export async function DeleteRule(input: DeleteRuleRequest): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexAdmin-DeleteRule:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -282,7 +284,7 @@ export async function DeleteRule(input: DeleteRuleRequest): Promise<void> {
 export async function FlushBlocks(): Promise<void> {
   try {
     
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -292,8 +294,9 @@ export async function FlushBlocks(): Promise<void> {
       url: `/opni-api/CortexAdmin/flush_blocks`
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexAdmin-FlushBlocks:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -311,8 +314,7 @@ export async function GetSeriesMetrics(input: SeriesRequest): Promise<SeriesInfo
       console.info('Here is the input for a request to CortexAdmin-GetSeriesMetrics:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => SeriesInfoList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -323,8 +325,9 @@ export async function GetSeriesMetrics(input: SeriesRequest): Promise<SeriesInfo
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = SeriesInfoList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-GetSeriesMetrics:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -342,8 +345,7 @@ export async function GetMetricLabelSets(input: LabelRequest): Promise<MetricLab
       console.info('Here is the input for a request to CortexAdmin-GetMetricLabelSets:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => MetricLabels.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -354,8 +356,9 @@ export async function GetMetricLabelSets(input: LabelRequest): Promise<MetricLab
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = MetricLabels.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-GetMetricLabelSets:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -369,8 +372,7 @@ export async function GetMetricLabelSets(input: LabelRequest): Promise<MetricLab
 export async function GetCortexStatus(): Promise<CortexStatus> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => CortexStatus.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -380,8 +382,9 @@ export async function GetCortexStatus(): Promise<CortexStatus> {
       url: `/opni-api/CortexAdmin/status`
     })).data;
 
+    const response = CortexStatus.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-GetCortexStatus:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -399,8 +402,7 @@ export async function GetCortexConfig(input: ConfigRequest): Promise<ConfigRespo
       console.info('Here is the input for a request to CortexAdmin-GetCortexConfig:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => ConfigResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -411,8 +413,9 @@ export async function GetCortexConfig(input: ConfigRequest): Promise<ConfigRespo
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = ConfigResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-GetCortexConfig:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -430,8 +433,7 @@ export async function ExtractRawSeries(input: MatcherRequest): Promise<QueryResp
       console.info('Here is the input for a request to CortexAdmin-ExtractRawSeries:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => QueryResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -442,8 +444,9 @@ export async function ExtractRawSeries(input: MatcherRequest): Promise<QueryResp
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = QueryResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexAdmin-ExtractRawSeries:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));

--- a/web/pkg/opni/generated/github.com/rancher/opni/plugins/metrics/apis/cortexops/cortexops_pb.ts
+++ b/web/pkg/opni/generated/github.com/rancher/opni/plugins/metrics/apis/cortexops/cortexops_pb.ts
@@ -383,14 +383,21 @@ export class DryRunRequest extends Message<DryRunRequest> {
   /**
    * Reset
    *
-   * @generated from field: cortexops.CapabilityBackendConfigSpec patch = 4;
+   * @generated from field: core.Revision revision = 4;
+   */
+  revision?: Revision;
+
+  /**
+   * Reset
+   *
+   * @generated from field: cortexops.CapabilityBackendConfigSpec patch = 5;
    */
   patch?: CapabilityBackendConfigSpec;
 
   /**
    * Reset
    *
-   * @generated from field: google.protobuf.FieldMask mask = 5;
+   * @generated from field: google.protobuf.FieldMask mask = 6;
    */
   mask?: FieldMask;
 
@@ -405,8 +412,9 @@ export class DryRunRequest extends Message<DryRunRequest> {
     { no: 1, name: "target", kind: "enum", T: proto3.getEnumType(Target) },
     { no: 2, name: "action", kind: "enum", T: proto3.getEnumType(Action) },
     { no: 3, name: "spec", kind: "message", T: CapabilityBackendConfigSpec },
-    { no: 4, name: "patch", kind: "message", T: CapabilityBackendConfigSpec },
-    { no: 5, name: "mask", kind: "message", T: FieldMask },
+    { no: 4, name: "revision", kind: "message", T: Revision },
+    { no: 5, name: "patch", kind: "message", T: CapabilityBackendConfigSpec },
+    { no: 6, name: "mask", kind: "message", T: FieldMask },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DryRunRequest {
@@ -517,12 +525,17 @@ export class ConfigurationHistoryResponse extends Message<ConfigurationHistoryRe
  */
 export class ResetRequest extends Message<ResetRequest> {
   /**
-   * @generated from field: google.protobuf.FieldMask mask = 1;
+   * @generated from field: core.Revision revision = 1;
+   */
+  revision?: Revision;
+
+  /**
+   * @generated from field: google.protobuf.FieldMask mask = 2;
    */
   mask?: FieldMask;
 
   /**
-   * @generated from field: cortexops.CapabilityBackendConfigSpec patch = 2;
+   * @generated from field: cortexops.CapabilityBackendConfigSpec patch = 3;
    */
   patch?: CapabilityBackendConfigSpec;
 
@@ -534,8 +547,9 @@ export class ResetRequest extends Message<ResetRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "cortexops.ResetRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "mask", kind: "message", T: FieldMask },
-    { no: 2, name: "patch", kind: "message", T: CapabilityBackendConfigSpec },
+    { no: 1, name: "revision", kind: "message", T: Revision },
+    { no: 2, name: "mask", kind: "message", T: FieldMask },
+    { no: 3, name: "patch", kind: "message", T: CapabilityBackendConfigSpec },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ResetRequest {

--- a/web/pkg/opni/generated/github.com/rancher/opni/plugins/metrics/apis/cortexops/cortexops_svc.ts
+++ b/web/pkg/opni/generated/github.com/rancher/opni/plugins/metrics/apis/cortexops/cortexops_svc.ts
@@ -14,8 +14,7 @@ export async function GetDefaultConfiguration(input: GetRequest): Promise<Capabi
       console.info('Here is the input for a request to CortexOps-GetDefaultConfiguration:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => CapabilityBackendConfigSpec.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -26,8 +25,9 @@ export async function GetDefaultConfiguration(input: GetRequest): Promise<Capabi
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = CapabilityBackendConfigSpec.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexOps-GetDefaultConfiguration:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -45,7 +45,7 @@ export async function SetDefaultConfiguration(input: CapabilityBackendConfigSpec
       console.info('Here is the input for a request to CortexOps-SetDefaultConfiguration:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -56,8 +56,9 @@ export async function SetDefaultConfiguration(input: CapabilityBackendConfigSpec
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexOps-SetDefaultConfiguration:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -71,7 +72,7 @@ export async function SetDefaultConfiguration(input: CapabilityBackendConfigSpec
 export async function ResetDefaultConfiguration(): Promise<void> {
   try {
     
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -81,8 +82,9 @@ export async function ResetDefaultConfiguration(): Promise<void> {
       url: `/opni-api/CortexOps/configuration/default`
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexOps-ResetDefaultConfiguration:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -100,8 +102,7 @@ export async function GetConfiguration(input: GetRequest): Promise<CapabilityBac
       console.info('Here is the input for a request to CortexOps-GetConfiguration:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => CapabilityBackendConfigSpec.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -112,8 +113,9 @@ export async function GetConfiguration(input: GetRequest): Promise<CapabilityBac
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = CapabilityBackendConfigSpec.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexOps-GetConfiguration:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -131,7 +133,7 @@ export async function SetConfiguration(input: CapabilityBackendConfigSpec): Prom
       console.info('Here is the input for a request to CortexOps-SetConfiguration:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'put',
       responseType: 'arraybuffer',
       headers: {
@@ -142,8 +144,9 @@ export async function SetConfiguration(input: CapabilityBackendConfigSpec): Prom
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexOps-SetConfiguration:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -161,7 +164,7 @@ export async function ResetConfiguration(input: ResetRequest): Promise<void> {
       console.info('Here is the input for a request to CortexOps-ResetConfiguration:', input);
     }
   
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'delete',
       responseType: 'arraybuffer',
       headers: {
@@ -172,8 +175,9 @@ export async function ResetConfiguration(input: ResetRequest): Promise<void> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexOps-ResetConfiguration:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -187,8 +191,7 @@ export async function ResetConfiguration(input: ResetRequest): Promise<void> {
 export async function Status(): Promise<InstallStatus> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => InstallStatus.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -198,8 +201,9 @@ export async function Status(): Promise<InstallStatus> {
       url: `/opni-api/CortexOps/status`
     })).data;
 
+    const response = InstallStatus.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexOps-Status:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -213,7 +217,7 @@ export async function Status(): Promise<InstallStatus> {
 export async function Install(): Promise<void> {
   try {
     
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -223,8 +227,9 @@ export async function Install(): Promise<void> {
       url: `/opni-api/CortexOps/install`
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexOps-Install:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -238,7 +243,7 @@ export async function Install(): Promise<void> {
 export async function Uninstall(): Promise<void> {
   try {
     
-    const response = (await axios.request({
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -248,8 +253,9 @@ export async function Uninstall(): Promise<void> {
       url: `/opni-api/CortexOps/uninstall`
     })).data;
 
+    const response = rawResponse;
     console.info('Here is the response for a request to CortexOps-Uninstall:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -263,8 +269,7 @@ export async function Uninstall(): Promise<void> {
 export async function ListPresets(): Promise<PresetList> {
   try {
     
-    const response = (await axios.request({
-    transformResponse: resp => PresetList.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -274,8 +279,9 @@ export async function ListPresets(): Promise<PresetList> {
       url: `/opni-api/CortexOps/presets`
     })).data;
 
+    const response = PresetList.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexOps-ListPresets:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -293,8 +299,7 @@ export async function DryRun(input: DryRunRequest): Promise<DryRunResponse> {
       console.info('Here is the input for a request to CortexOps-DryRun:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => DryRunResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'post',
       responseType: 'arraybuffer',
       headers: {
@@ -305,8 +310,9 @@ export async function DryRun(input: DryRunRequest): Promise<DryRunResponse> {
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = DryRunResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexOps-DryRun:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));
@@ -324,8 +330,7 @@ export async function ConfigurationHistory(input: ConfigurationHistoryRequest): 
       console.info('Here is the input for a request to CortexOps-ConfigurationHistory:', input);
     }
   
-    const response = (await axios.request({
-    transformResponse: resp => ConfigurationHistoryResponse.fromBinary(new Uint8Array(resp)),
+    const rawResponse = (await axios.request({
       method: 'get',
       responseType: 'arraybuffer',
       headers: {
@@ -336,8 +341,9 @@ export async function ConfigurationHistory(input: ConfigurationHistoryRequest): 
     data: input?.toBinary() as ArrayBuffer
     })).data;
 
+    const response = ConfigurationHistoryResponse.fromBinary(new Uint8Array(rawResponse))
     console.info('Here is the response for a request to CortexOps-ConfigurationHistory:', response);
-    return response
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));

--- a/web/service-generator/src/index.ts
+++ b/web/service-generator/src/index.ts
@@ -46,7 +46,7 @@ function printMethod(f: GeneratedFile, method: DescMethod, service: DescService)
   // const inputType = input.name === 'Empty' ? '' : input.name;
   // const returnType = output.name === 'Empty' ? 'void' : output.name;
   // const transformRequest = inputIsEmpty ? '' : `\n    transformRequest: req => req.toJsonString(),`;
-  const transformResponse = outputIsEmpty ? '' : [`\n    transformResponse: resp => `, output, `.fromBinary(new Uint8Array(resp)),`];
+  // const transformResponse = outputIsEmpty ? '' : [`\n    transformResponse: resp => `, output, `.fromBinary(new Uint8Array(resp)),`];
   const data = inputIsEmpty ? '' : `,\n    data: input?.toBinary() as ArrayBuffer`;
   const urlPath = (m?.pattern.value as any || '').replaceAll('{', '${input.');
   const potentialModelPath = output ? path.join('./web/pkg/opni/models', service.name, `${ output.name }.ts`) : '';
@@ -59,7 +59,7 @@ function printMethod(f: GeneratedFile, method: DescMethod, service: DescService)
     }
   `;
 
-  const returnText = modelImport ? [`return new `, modelImport, `(response)`] : [`return response`];
+  const responseTranform = outputIsEmpty ? [`rawResponse;`] : [output, `.fromBinary(new Uint8Array(rawResponse))`];
 
   switch (method.methodKind) {
   case MethodKind.Unary:
@@ -67,7 +67,7 @@ function printMethod(f: GeneratedFile, method: DescMethod, service: DescService)
 export async function ${ method.name }(`, ...(inputIsEmpty ? [] : ['input: ', input]), `): Promise<`, outputIsEmpty ? 'void' : modelImport || output, `> {
   try {
     ${ inputLogMessage }
-    const response = (await `, _axios, `.request({`, ...transformResponse, `
+    const rawResponse = (await `, _axios, `.request({
       method: '${ m?.pattern.case || 'get' }',
       responseType: 'arraybuffer',
       headers: {
@@ -77,8 +77,9 @@ export async function ${ method.name }(`, ...(inputIsEmpty ? [] : ['input: ', in
       url: \`/opni-api/${ method.parent.name }${ urlPath }\`${ data }
     })).data;
 
+    const response = `, ...responseTranform, `
     console.info('Here is the response for a request to ${ service.name }-${ method.name }:', response);
-    `, ...returnText, `
+    return response;
   } catch (ex: any) {
     if (ex?.response?.data) {
       const s = String.fromCharCode.apply(null, Array.from(new Uint8Array(ex?.response?.data)));


### PR DESCRIPTION
Previously when a service would return an error we'd fail to deserialize it. This will now get the status error at the very least. It would be nice to get the actual error object but I'm not sure if that's possible yet. It doesn't look like the ErrorInfo object is getting created and I'm not positive if that object is guaranteed for errors.

Old error: 
![Screenshot 2023-10-26 121036](https://github.com/rancher/opni/assets/55104481/bd09c677-df58-4524-8beb-6d7cc4bcae3c)


New error:
![Screenshot 2023-10-26 122324](https://github.com/rancher/opni/assets/55104481/0dd80141-338b-4ce3-ac59-482f2fda5f02)

