### PR TITLE
handle uninstall edge case for partial install failures

### DIFF
--- a/plugins/logging/pkg/gateway/admin_v2.go
+++ b/plugins/logging/pkg/gateway/admin_v2.go
@@ -87,7 +87,8 @@ func (m *LoggingManagerV2) DeleteOpensearchCluster(ctx context.Context, _ *empty
 
 	// Remove the state tracking the initial admin
 	err := m.opensearchManager.DeleteInitialAdminState()
-	if err != nil {
+	st, _ := grpcstatus.FromError(err)
+	if err != nil && st.Code() != codes.NotFound {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes https://github.com/rancher/opni/issues/1816

Context for this fix : After uninstalling and forgetting to delete the opni-quorum PVC, the cluster will fail to initialize (as expected) but the KV won't be populated causing the uninstall request to fail from the management API.