### PR TITLE
sanitize short uuids with url.PathEscape

### DIFF
--- a/pkg/alerting/drivers/cortex/cortex.go
+++ b/pkg/alerting/drivers/cortex/cortex.go
@@ -2,6 +2,7 @@ package cortex
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -66,6 +67,7 @@ func NewPrometheusAlertingRule(
 	interval *time.Duration,
 	rule metrics.AlertRuleBuilder,
 ) (ruleGroup *rulefmt.RuleGroup, metadata map[string]string, err error) {
+	alertId = url.PathEscape(alertId) // prevents cortex from silently failing with BadKey
 	idLabels := ConstructIdLabelsForRecordingRule(alertId)
 	alertingRule, err := rule.Build(alertId)
 	if err != nil {

--- a/plugins/alerting/pkg/alerting/alarms/v1/rules_sync.go
+++ b/plugins/alerting/pkg/alerting/alarms/v1/rules_sync.go
@@ -3,6 +3,7 @@ package alarms
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/google/go-cmp/cmp"
 	alertingv1 "github.com/rancher/opni/pkg/apis/alerting/v1"
@@ -64,7 +65,7 @@ func (a *AlarmServerComponent) SyncRules(ctx context.Context, rules *rules.RuleM
 		incomingCond := &alertingv1.AlertCondition{
 			// immutable sync fields
 			Id:      rule.RuleId.Id,
-			GroupId: rule.GroupId.Id,
+			GroupId: url.PathEscape(rule.GroupId.Id),
 			AlertType: &alertingv1.AlertTypeDetails{
 				Type: &alertingv1.AlertTypeDetails_PrometheusQuery{
 					PrometheusQuery: &alertingv1.AlertConditionPrometheusQuery{


### PR DESCRIPTION
Prevents de-serialization mistakes down the line in cortex ruler store