### PR TITLE
fix: remove empty field in the releaser configuration.

### DIFF
--- a/dagger/config/config.go
+++ b/dagger/config/config.go
@@ -214,8 +214,7 @@ func mergeStrict(src, dest map[string]any) error {
 				// Handle the special case where empty slices are decoded as []any causing
 				// a type mismatch when merging with a slice of a specific type.
 				if reflect.TypeOf(dest[key]).Kind() == reflect.Slice &&
-					reflect.TypeOf(val) == reflect.TypeOf(([]any)(nil)) &&
-					reflect.ValueOf(dest[key]).Len() == 0 {
+					reflect.TypeOf(val) == reflect.TypeOf(([]any)(nil)) {
 					dest[key] = reflect.MakeSlice(reflect.TypeOf(dest[key]), 0, 0).Interface()
 					for _, v := range val.([]any) {
 						dest[key] = reflect.Append(reflect.ValueOf(dest[key]), reflect.ValueOf(v)).Interface()


### PR DESCRIPTION
The setup command is writing a file with the `releaser.os` and `releaser.arch` fields as empty lists. This is causing problems in the merge of the default configuration and the configuration generated by the command. During the merge the fields from the files are considered different types causing a failure. As the generate file should be used to overwrite the default values does not make sense to write a file with a invalid field value (empty list). Therefore, this commit change the setup command to remove the mentioned field from the file when they are empty.

Fix #1829 