### PR TITLE
Fix panic in testenv metrics cluster driver

### DIFF
--- a/plugins/metrics/test/test_drivers.go
+++ b/plugins/metrics/test/test_drivers.go
@@ -216,7 +216,10 @@ func (d *TestEnvMetricsClusterDriver) onActiveConfigChanged(old, new *cortexops.
 			d.stopCortexCmdAfter()
 		}
 		d.cortexCancel()
-		<-d.cortexCmdCtx.Done()
+		if d.cortexCmdCtx != nil {
+			// can be nil if the previous cortex command failed to start
+			<-d.cortexCmdCtx.Done()
+		}
 	}
 
 	// NB: apply changes to currentStatus instead of d.status in this function


### PR DESCRIPTION
Fix panic in testenv metrics cluster driver when reconfiguring after the previous config caused cortex to fail to start