### PR TITLE
Use correct release-name annotation in Charts

### DIFF
--- a/packages/opni-agent/opni-agent/charts/Chart.yaml
+++ b/packages/opni-agent/opni-agent/charts/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   catalog.cattle.io/display-name: Opni Agent
   catalog.cattle.io/os: linux
-  catalog.rancher.io/namespace: opni-system
-  catalog.rancher.io/release-name: opni-agent
+  catalog.cattle.io/namespace: opni
+  catalog.cattle.io/release-name: opni-agent
 apiVersion: v2
 appVersion: 0.12.1
 dependencies:

--- a/packages/opni/opni/charts/Chart.yaml
+++ b/packages/opni/opni/charts/Chart.yaml
@@ -2,8 +2,8 @@ annotations:
   catalog.cattle.io/auto-install: opni-crd=match
   catalog.cattle.io/display-name: Opni
   catalog.cattle.io/os: linux
-  catalog.rancher.io/namespace: opni-cluster-system
-  catalog.rancher.io/release-name: opni
+  catalog.cattle.io/namespace: opni
+  catalog.cattle.io/release-name: opni
 apiVersion: v2
 appVersion: 0.12.1
 dependencies:

--- a/packages/opni/opni/templates/crd-template/Chart.yaml
+++ b/packages/opni/opni/templates/crd-template/Chart.yaml
@@ -1,3 +1,8 @@
+annotations:
+  catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/release-name: opni-crd
+  catalog.cattle.io/namespace: opni
+  catalog.cattle.io/display-name: Opni CRDs
 apiVersion: v1
 version: 0.5.4
 description: Installs the CRDs for Opni.
@@ -8,7 +13,3 @@ maintainers:
   name: Joe Kralicky
 - email: dan.bason@suse.com
   name: Dan Bason
-annotations:
-  catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/release-name: opni-crd
-  catalog.cattle.io/namespace: opni-cluster-system


### PR DESCRIPTION
Now, the Rancher UI asks for the project instead of the name: 
![image](https://github.com/rancher/opni/assets/30930799/1c070f57-76b6-4cbf-b925-6679494c57f9)

Fixes #1861 

To test, I created an updated "mock" branch called [charts-repo-test-name](https://github.com/rancher/opni/compare/charts-repo...charts-repo-test-name).