### PR TITLE
Fix slog handler edge cases

### DIFF
--- a/pkg/logger/color_handler.go
+++ b/pkg/logger/color_handler.go
@@ -348,7 +348,7 @@ func (h *colorHandler) appendValue(buf *buffer, v slog.Value, shouldQuote bool) 
 		case *slog.Source:
 			h.appendSource(buf, cv.File, cv.Line)
 		default:
-			h.appendString(buf, fmt.Sprint(v.Any()), shouldQuote)
+			h.appendString(buf, fmt.Sprint(cv), shouldQuote)
 		}
 	}
 }

--- a/pkg/logger/color_handler.go
+++ b/pkg/logger/color_handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"sync"
@@ -335,6 +336,10 @@ func (h *colorHandler) appendValue(buf *buffer, v slog.Value, shouldQuote bool) 
 		case slog.Level:
 			h.appendLevel(buf, cv)
 		case encoding.TextMarshaler:
+			if reflect.ValueOf(cv).IsNil() {
+				h.appendString(buf, "", shouldQuote)
+				break
+			}
 			data, err := cv.MarshalText()
 			if err != nil {
 				break

--- a/pkg/logger/color_handler_test.go
+++ b/pkg/logger/color_handler_test.go
@@ -161,7 +161,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.WithGroup("group").Info("test", "key", "val", "key2", "val2")
 			},
-			Want: `2009 Nov 10 23:00:00 INFO group test key=val key2=val2`,
+			Want: `2009 Nov 10 23:00:00 INFO group test key2=val2`,
 		},
 		{
 			Opts: &LoggerOptions{

--- a/pkg/logger/color_handler_test.go
+++ b/pkg/logger/color_handler_test.go
@@ -333,6 +333,14 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `2009 Nov 10 23:00:00 ERROR group test err=fail`,
 		},
+		{
+			F: func(l *slog.Logger) {
+				var t *T
+				l = l.With("t", t)
+				l.Info("test")
+			},
+			Want: `2009 Nov 10 23:00:00 INFO test t=""`,
+		},
 	}
 
 	for i, test := range tests {
@@ -523,3 +531,11 @@ var (
 	testDuration = 23 * time.Second
 	errTest      = errors.New("fail")
 )
+
+type T struct {
+	U
+}
+
+type U interface {
+	MarshalText() ([]byte, error)
+}

--- a/pkg/logger/color_handler_test.go
+++ b/pkg/logger/color_handler_test.go
@@ -98,7 +98,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "val")
 			},
-			Want: `2009 Nov 10 23:00:00 INFO logger/color_handler_test.go:98 test key=val`,
+			Want: `2009 Nov 10 23:00:00 INFO logger/color_handler_test.go:99 test key=val`,
 		},
 		{
 			Opts: &LoggerOptions{
@@ -107,7 +107,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "val")
 			},
-			Want: `INFO test key=val`,
+			Want: `2009 Nov 10 23:00:00 INFO test key=val`,
 		},
 		{
 			Opts: &LoggerOptions{
@@ -324,7 +324,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `2009 Nov 10 23:00:00 INFO logger/color_handler_test.go:324 test`,
+			Want: `2009 Nov 10 23:00:00 INFO logger/color_handler_test.go:325 test`,
 		},
 		{
 			F: func(l *slog.Logger) {


### PR DESCRIPTION
- logging nil pointer to `encoding.TextMarshaler`
- updates tests to reflect decision to enforce timestamps on all logs
- fixes typo for expected output when dropping an attribute